### PR TITLE
ci: APK 命名(arm64 主包去后缀) + tag 触发兼容 2.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "[0-9]*"
   workflow_dispatch:
     inputs:
       tag_name:
@@ -135,7 +136,12 @@ jobs:
           mkdir -p "$OUT"
           for abi in arm64-v8a armeabi-v7a x86_64 universal; do
             f="$APKDIR/app-${abi}-release.apk"
-            [ -f "$f" ] && cp "$f" "$OUT/xplayer-${VERSION}-${abi}.apk"
+            [ -f "$f" ] || continue
+            if [ "$abi" = "arm64-v8a" ]; then
+              cp "$f" "$OUT/xplayer-${VERSION}.apk"            # 主包(arm64-v8a)不带后缀
+            else
+              cp "$f" "$OUT/xplayer-${VERSION}-${abi}.apk"
+            fi
           done
           # fallback if split was not enabled
           [ -f "$APKDIR/app-release.apk" ] && cp "$APKDIR/app-release.apk" "$OUT/xplayer-${VERSION}.apk" || true


### PR DESCRIPTION
arm64-v8a 主包改名为 xplayer-<版本>.apk(不带 ABI 后缀),其余 ABI 保留后缀;release.yml 触发器新增 [0-9]* 以兼容裸版本号 tag(如 2.0.0,仍兼容 v*)。