### PR TITLE
ci: Windows 构建非阻塞,避免拖垮发布

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,9 @@ jobs:
   windows:
     name: Windows (zip)
     runs-on: windows-latest
+    # Windows 桌面构建在 windows-latest 偶发 VS 检测失败(Flutter 3.27 × VS2022),
+    # 不应阻塞整个发布;失败时其它平台照常发版。
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -527,6 +530,7 @@ jobs:
 
       - name: Download Windows artifact
         uses: actions/download-artifact@v4
+        continue-on-error: true  # Windows 失败时无产物,跳过不阻塞发布
         with:
           name: windows
           path: ./dist/windows


### PR DESCRIPTION
windows-latest 上 Flutter 3.27.3 偶发选用 VS2019 生成器,Windows 桌面构建失败,进而(release job needs windows)跳过整个发布。改为 continue-on-error:Windows 失败时其余平台(含已签名 Android APK)照常发版。