### PR TITLE
ci: 钉 Windows runner 到 windows-2022

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,9 +158,9 @@ jobs:
 
   windows:
     name: Windows (zip)
-    runs-on: windows-latest
-    # Windows 桌面构建在 windows-latest 偶发 VS 检测失败(Flutter 3.27 × VS2022),
-    # 不应阻塞整个发布;失败时其它平台照常发版。
+    # 钉到 windows-2022:windows-latest 已滚到更新镜像,Flutter 3.27.3 在其上会误选
+    # VS2019 生成器导致构建失败(2025-10 旧镜像上还是好的)。保留 continue-on-error 兜底。
+    runs-on: windows-2022
     continue-on-error: true
     steps:
       - name: Checkout


### PR DESCRIPTION
windows-latest 镜像漂移(疑迁至 Server 2025 / VS 补丁变更)导致 Flutter 3.27.3 误选 VS2019 生成器、Windows 构建失败(2025-10 旧镜像上正常)。钉到 windows-2022 退回可用镜像;仍保留 continue-on-error 兜底。下次发版验证。