### PR TITLE
fix(ci): 修正 APK 重命名(主包错成 universal)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,17 +134,18 @@ jobs:
           APKDIR=build/app/outputs/flutter-apk
           OUT=dist-android
           mkdir -p "$OUT"
-          for abi in arm64-v8a armeabi-v7a x86_64 universal; do
+          # 按 ABI 拆分的瘦包:arm64-v8a 作主包(不带后缀),其余带后缀
+          for abi in arm64-v8a armeabi-v7a x86_64; do
             f="$APKDIR/app-${abi}-release.apk"
             [ -f "$f" ] || continue
             if [ "$abi" = "arm64-v8a" ]; then
-              cp "$f" "$OUT/xplayer-${VERSION}.apk"            # 主包(arm64-v8a)不带后缀
+              cp "$f" "$OUT/xplayer-${VERSION}.apk"
             else
               cp "$f" "$OUT/xplayer-${VERSION}-${abi}.apk"
             fi
           done
-          # fallback if split was not enabled
-          [ -f "$APKDIR/app-release.apk" ] && cp "$APKDIR/app-release.apk" "$OUT/xplayer-${VERSION}.apk" || true
+          # 通用兜底包:universalApk 经 Flutter 输出为 flutter-apk/app-release.apk(含全部 ABI)
+          [ -f "$APKDIR/app-release.apk" ] && cp "$APKDIR/app-release.apk" "$OUT/xplayer-${VERSION}-universal.apk"
           AAB=build/app/outputs/bundle/release/app-release.aab
           [ -f "$AAB" ] && cp "$AAB" "$OUT/xplayer-${VERSION}.aab"
           echo "== renamed artifacts ==" && ls -la "$OUT"


### PR DESCRIPTION
之前 fallback 行把 universalApk 的 app-release.apk(全 ABI,~27MB)覆盖到了主包 xplayer-<ver>.apk,导致主包变成通用包、真正的 arm64 瘦包(~11MB)丢失。改为:arm64-v8a→主包(不带后缀);app-release.apk→ -universal 后缀;删除覆盖式 fallback。本地 split 构建已确认文件名与体积。