### PR TITLE
feat: Android TV 搜索框焦点可移出 + 在线更新自定义 HTTP 代理

### DIFF
--- a/lib/localization/app_en.arb
+++ b/lib/localization/app_en.arb
@@ -114,5 +114,7 @@
   "presetDisclaimer": "Channels come from the public iptv-org list (aggregation only) and can be removed anytime.",
   "search": "Search",
   "searchChannelsHint": "Search channel name",
-  "allGroups": "All"
+  "allGroups": "All",
+  "updateProxy": "Update Proxy",
+  "updateProxyHint": "Route update downloads through this HTTP proxy (host:port) to speed them up; empty = direct. Updates only — playback is unaffected."
 }

--- a/lib/localization/app_zh.arb
+++ b/lib/localization/app_zh.arb
@@ -114,5 +114,7 @@
     "presetDisclaimer": "直播源来自 iptv-org 公开列表，仅做聚合，可随时删除。",
     "search": "搜索",
     "searchChannelsHint": "搜索频道名称",
-    "allGroups": "全部"
+    "allGroups": "全部",
+    "updateProxy": "更新代理",
+    "updateProxyHint": "在线更新走此 HTTP 代理（host:port），加速下载；留空直连。仅用于更新，不影响播放。"
 }

--- a/lib/presentation/screens/home.dart
+++ b/lib/presentation/screens/home.dart
@@ -11,6 +11,7 @@ import 'package:xplayer/presentation/widgets/channel_list_widget.dart';
 import 'package:xplayer/presentation/widgets/channel_filter_bar.dart';
 import 'package:xplayer/presentation/widgets/playlist_dialog.dart';
 import 'package:xplayer/presentation/widgets/preset_source_dialog.dart';
+import 'package:xplayer/presentation/widgets/update_proxy_dialog.dart';
 import 'package:xplayer/shared/components/x_text_button.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:xplayer/providers/locale_provider.dart';
@@ -436,6 +437,25 @@ class _HomeScreenState extends State<HomeScreen> {
                     Navigator.of(context).pop();
                     await UpdateService.checkUpdateWithUI(context);
                   },
+                ),
+                XBaseButton(
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    showDialog(
+                      context: context,
+                      builder: (_) => const UpdateProxyDialog(),
+                    );
+                  },
+                  child: animeContainer(
+                    ListTile(
+                      leading: const Icon(Icons.settings_ethernet,
+                          color: Colors.white),
+                      title: Text(
+                        localizations.updateProxy,
+                        style: const TextStyle(color: Colors.white),
+                      ),
+                    ),
+                  ),
                 ),
                 ListTile(
                   leading: const Icon(Icons.info, color: Colors.white),

--- a/lib/presentation/widgets/channel_filter_bar.dart
+++ b/lib/presentation/widgets/channel_filter_bar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:xplayer/providers/media_provider.dart';
@@ -18,17 +19,37 @@ class ChannelFilterBar extends StatefulWidget {
 
 class _ChannelFilterBarState extends State<ChannelFilterBar> {
   late final TextEditingController _controller;
+  final FocusNode _searchFocus = FocusNode(debugLabel: 'channelSearch');
 
   @override
   void initState() {
     super.initState();
     final media = Provider.of<MediaProvider>(context, listen: false);
     _controller = TextEditingController(text: media.searchQuery);
+    // TV 遥控:单行搜索框会吞掉上/下方向键,导致"焦点进去出不来"。
+    // 聚焦搜索框时拦截上/下键,把焦点移出到上方(AppBar)或下方(分组 chips / 频道网格);
+    // 左/右键不拦截,仍用于文本光标移动。
+    _searchFocus.onKeyEvent = (node, event) {
+      if (event is KeyDownEvent || event is KeyRepeatEvent) {
+        if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+          return node.focusInDirection(TraversalDirection.down)
+              ? KeyEventResult.handled
+              : KeyEventResult.ignored;
+        }
+        if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+          return node.focusInDirection(TraversalDirection.up)
+              ? KeyEventResult.handled
+              : KeyEventResult.ignored;
+        }
+      }
+      return KeyEventResult.ignored;
+    };
   }
 
   @override
   void dispose() {
     _controller.dispose();
+    _searchFocus.dispose();
     super.dispose();
   }
 
@@ -61,6 +82,7 @@ class _ChannelFilterBarState extends State<ChannelFilterBar> {
               AppDimens.s8, AppDimens.s8, AppDimens.s8, AppDimens.s4),
           child: TextField(
             controller: _controller,
+            focusNode: _searchFocus,
             style: const TextStyle(color: AppTokens.textPrimary),
             cursorColor: AppTokens.brand,
             textInputAction: TextInputAction.search,

--- a/lib/presentation/widgets/update_proxy_dialog.dart
+++ b/lib/presentation/widgets/update_proxy_dialog.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:xplayer/services/update/update_proxy.dart';
+import 'package:xplayer/shared/components/x_text_button.dart';
+import 'package:xplayer/shared/theme/app_tokens.dart';
+
+/// 在线更新代理设置对话框（`host:port`）。留空保存即清除（直连）。
+class UpdateProxyDialog extends StatefulWidget {
+  const UpdateProxyDialog({super.key});
+
+  @override
+  State<UpdateProxyDialog> createState() => _UpdateProxyDialogState();
+}
+
+class _UpdateProxyDialogState extends State<UpdateProxyDialog> {
+  final TextEditingController _controller = TextEditingController();
+  final FocusNode _focus = FocusNode(debugLabel: 'updateProxy');
+
+  @override
+  void initState() {
+    super.initState();
+    UpdateProxy.get().then((v) {
+      if (mounted) _controller.text = v ?? '';
+    });
+    // TV:上/下方向键把焦点移出文本框,避免被困(同搜索框处理)
+    _focus.onKeyEvent = (node, event) {
+      if (event is KeyDownEvent || event is KeyRepeatEvent) {
+        if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+          return node.focusInDirection(TraversalDirection.down)
+              ? KeyEventResult.handled
+              : KeyEventResult.ignored;
+        }
+        if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+          return node.focusInDirection(TraversalDirection.up)
+              ? KeyEventResult.handled
+              : KeyEventResult.ignored;
+        }
+      }
+      return KeyEventResult.ignored;
+    };
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focus.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    await UpdateProxy.set(_controller.text); // 空 = 清除(直连)
+    if (mounted) Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context)!;
+    return AlertDialog(
+      backgroundColor: AppTokens.surfacePanel,
+      title: Text(l.updateProxy,
+          style: const TextStyle(color: AppTokens.textPrimary)),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            l.updateProxyHint,
+            style: const TextStyle(color: AppTokens.textTertiary, fontSize: 12),
+          ),
+          const SizedBox(height: AppDimens.s12),
+          TextField(
+            controller: _controller,
+            focusNode: _focus,
+            autocorrect: false,
+            enableSuggestions: false,
+            keyboardType: TextInputType.url,
+            style: const TextStyle(color: AppTokens.textPrimary),
+            cursorColor: AppTokens.brand,
+            decoration: const InputDecoration(
+              hintText: '127.0.0.1:7890',
+              hintStyle: TextStyle(color: AppTokens.textTertiary),
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        XTextButton(
+          text: l.cancel,
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        XTextButton(
+          text: l.save,
+          type: XTextButtonType.primary,
+          onPressed: _save,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/services/update/update_downloader.dart
+++ b/lib/services/update/update_downloader.dart
@@ -1,11 +1,13 @@
 import 'dart:io';
 import 'package:dio/dio.dart';
+import 'package:dio/io.dart';
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:xplayer/shared/components/x_text_button.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'update_result.dart';
 import 'update_cache.dart';
+import 'update_proxy.dart';
 
 /// 更新下载管理类
 class UpdateDownloader {
@@ -119,6 +121,19 @@ class UpdateDownloader {
           ),
         );
       }
+
+      // 配置在线更新代理(若已设置):仅用于本次 APK 下载,加速国内更新
+      final proxy = await UpdateProxy.get();
+      _dio.httpClientAdapter = IOHttpClientAdapter(
+        createHttpClient: () {
+          final client = HttpClient();
+          if (proxy != null) {
+            client.findProxy = (uri) => 'PROXY $proxy';
+            client.badCertificateCallback = (cert, host, port) => true;
+          }
+          return client;
+        },
+      );
 
       // 开始下载
       await _dio.download(

--- a/lib/services/update/update_proxy.dart
+++ b/lib/services/update/update_proxy.dart
@@ -1,0 +1,28 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 在线更新下载使用的 HTTP 代理（`host:port`）。
+///
+/// **仅作用于 APK / 安装包下载**（国内 GitHub 下载慢），不影响直播流播放、EPG 等。
+class UpdateProxy {
+  UpdateProxy._();
+
+  static const String prefKey = 'update_proxy';
+
+  /// 读取已保存的代理（`host:port`）；未设置返回 null。
+  static Future<String?> get() async {
+    final prefs = await SharedPreferences.getInstance();
+    final v = prefs.getString(prefKey)?.trim();
+    return (v == null || v.isEmpty) ? null : v;
+  }
+
+  /// 保存代理；传空字符串/ null 则清除（恢复直连）。
+  static Future<void> set(String? value) async {
+    final prefs = await SharedPreferences.getInstance();
+    final v = (value ?? '').trim();
+    if (v.isEmpty) {
+      await prefs.remove(prefKey);
+    } else {
+      await prefs.setString(prefKey, v);
+    }
+  }
+}


### PR DESCRIPTION
1) 修复 Android TV 遥控进入搜索框后焦点出不来:聚焦时拦截上/下方向键,把焦点移出到 AppBar / 分组 chips / 频道网格(左右键仍用于文本)。
2) 新增「更新代理」(抽屉菜单):为在线更新的 APK 下载配置 HTTP 代理(host:port),加速国内更新;仅作用于更新下载,不影响播放;留空直连。代理输入框同样做了 TV 焦点移出处理。