### PR TITLE
fix(ci): 修正发布变更记录的「上个 tag」计算

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -558,8 +558,9 @@ jobs:
         id: notes
         run: |
           TAG="${{ steps.meta.outputs.tag_name }}"
-          # 获取上一个 tag（不含当前 tag）
-          PREV_TAG=$(git tag --list --sort=-version:refname | grep -v "^${TAG}$" | head -n1)
+          # 上一个发布 tag = 历史上最近的祖先「版本」tag(排除 manual-* 等非版本 tag),
+          # 避免 --sort=-version:refname 把 manual-* 排到最前、导致变更记录跨越多个版本。
+          PREV_TAG=$(git describe --tags --abbrev=0 --match '[0-9]*' --match 'v[0-9]*' HEAD^ 2>/dev/null || true)
           echo "Current tag: $TAG"
           echo "Previous tag: $PREV_TAG"
           # 生成 commit 列表（排除 merge commit）


### PR DESCRIPTION
之前用 `git tag --sort=-version:refname` 取上个 tag,被遗留的 `manual-*` tag 排到最前 → 变更记录跨越多个版本(2.0.1 误列 40 个 commit)。改用 `git describe --abbrev=0 --match 版本号 HEAD^` 按祖先取最近版本 tag(2.0.1→2.0.0)。已同时手动修正 2.0.1 的 release notes。