### PR TITLE
fix(windows): 兜底强制显示窗口,修复安装后双击无窗口

### DIFF
--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -4,6 +4,15 @@
 
 #include "flutter/generated_plugin_registrant.h"
 
+namespace {
+// 兜底:部分 Windows GPU/驱动组合下,引擎首帧回调始终不触发,
+// 导致窗口永远不 Show(进程常驻、却看不到窗口)。该定时器保证启动后
+// 无论如何都会把窗口显示出来。正常机器上首帧回调早已先把窗口显示,
+// 定时器到点时 Show() 即为无害的空操作。
+constexpr UINT_PTR kShowWindowFallbackTimerId = 1;
+constexpr UINT kShowWindowFallbackTimeoutMs = 800;
+}  // namespace
+
 FlutterWindow::FlutterWindow(const flutter::DartProject& project)
     : project_(project) {}
 
@@ -36,6 +45,10 @@ bool FlutterWindow::OnCreate() {
   // window is shown. It is a no-op if the first frame hasn't completed yet.
   flutter_controller_->ForceRedraw();
 
+  // 兜底:即使首帧回调不触发,也在超时后强制显示窗口。
+  SetTimer(GetHandle(), kShowWindowFallbackTimerId,
+           kShowWindowFallbackTimeoutMs, nullptr);
+
   return true;
 }
 
@@ -64,6 +77,13 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
   switch (message) {
     case WM_FONTCHANGE:
       flutter_controller_->engine()->ReloadSystemFonts();
+      break;
+    case WM_TIMER:
+      if (wparam == kShowWindowFallbackTimerId) {
+        KillTimer(hwnd, kShowWindowFallbackTimerId);
+        this->Show();
+        return 0;
+      }
       break;
   }
 


### PR DESCRIPTION
## 问题
多台 Windows 机器均复现:安装后双击 `xplayer.exe` 无任何反应。排查结论:
- 进程**常驻**任务管理器、消息循环在跑 → 窗口与 Flutter engine 都创建成功;
- 无崩溃日志、无控制台输出、文件齐全、非 N/Server 版、物理机也复现;
- 即引擎**首帧回调 `SetNextFrameCallback` 未触发**,而默认 runner 仅在首帧到来时才 `Show()`,导致窗口永远隐藏。

## 修复
`windows/runner/flutter_window.cpp` 增加 800ms 定时器兜底:首帧回调没来也强制 `Show()`。
正常机器仍由首帧回调先显示,定时器到点 `Show()` 为无害空操作。

若个别机器 `Show` 后窗口空白,则可判定为该机 GPU/ANGLE 渲染问题(另行处理)。

## 验证
- 仅改 Windows runner C++,标准 Win32 调用(SetTimer/KillTimer/WM_TIMER),不影响其它平台;
- macOS 无法本地构建 Windows,将随 2.0.3 release 产出安装包验证。