### PR TITLE
fix(windows): 补 sqlite3_flutter_libs + 启动诊断日志(定位白屏)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,23 +10,57 @@ import 'package:xplayer/providers/media_provider.dart';
 import 'package:bot_toast/bot_toast.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'dart:io';
+import 'dart:async';
 import 'package:xplayer/providers/remote_provider.dart';
 import 'package:xplayer/presentation/screens/remote_input.dart';
 import 'package:xplayer/shared/navigation.dart';
 import 'package:xplayer/shared/theme/app_theme.dart';
 
+/// 启动诊断日志(仅 Windows):写到 %TEMP%\xplayer_startup.log。
+/// release 版控制台不可靠,用文件日志定位"白屏不出帧"卡在哪一步。
+void _winLog(String msg) {
+  if (!Platform.isWindows) return;
+  try {
+    final f = File('${Directory.systemTemp.path}\\xplayer_startup.log');
+    f.writeAsStringSync(
+      '${DateTime.now().toIso8601String()}  $msg\n',
+      mode: FileMode.append,
+      flush: true,
+    );
+  } catch (_) {}
+}
+
 void main() {
-  WidgetsFlutterBinding.ensureInitialized();
-  if (Platform.isWindows || Platform.isLinux) {
-    sqfliteFfiInit();
-    databaseFactory = databaseFactoryFfi;
-  }
-  runApp(MultiProvider(providers: [
-    ChangeNotifierProvider(create: (_) => MediaProvider()),
-    ChangeNotifierProvider(create: (_) => LocaleProvider()..loadLocale()),
-    ChangeNotifierProvider(create: (_) => GlobalProvider()..loadDeviceInfo()),
-    ChangeNotifierProvider(create: (_) => RemoteProvider()),
-  ], child: const MyApp()));
+  runZonedGuarded(() {
+    WidgetsFlutterBinding.ensureInitialized();
+    _winLog('binding initialized');
+
+    FlutterError.onError = (FlutterErrorDetails details) {
+      _winLog('FlutterError: ${details.exceptionAsString()}');
+      FlutterError.presentError(details);
+    };
+
+    if (Platform.isWindows || Platform.isLinux) {
+      sqfliteFfiInit();
+      databaseFactory = databaseFactoryFfi;
+      _winLog('sqflite ffi init done');
+    }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _winLog('first frame built');
+    });
+
+    _winLog('calling runApp');
+    runApp(MultiProvider(providers: [
+      ChangeNotifierProvider(create: (_) => MediaProvider()),
+      ChangeNotifierProvider(create: (_) => LocaleProvider()..loadLocale()),
+      ChangeNotifierProvider(create: (_) => GlobalProvider()..loadDeviceInfo()),
+      ChangeNotifierProvider(create: (_) => RemoteProvider()),
+    ], child: const MyApp()));
+    _winLog('runApp returned');
+  }, (Object error, StackTrace stack) {
+    _winLog('ZONE ERROR: $error\n$stack');
+  });
 }
 
 class MyApp extends StatelessWidget {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -863,6 +863,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.7.2"
+  sqlite3_flutter_libs:
+    dependency: "direct main"
+    description:
+      name: sqlite3_flutter_libs
+      sha256: eeb9e3a45207649076b808f8a5a74d68770d0b7f26ccef6d5f43106eee5375ad
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.42"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   sqflite: ^2.3.2
   sqflite_common: ^2.5.4+6
   sqflite_common_ffi: ^2.3.4+4
+  # 桌面端(Windows/Linux)用 FFI 时需要它打包 sqlite3 原生库,否则开库失败
+  sqlite3_flutter_libs: ^0.5.0
   url_launcher: ^6.3.1
   video_player: ^2.9.2
   video_player_win: ^3.1.1


### PR DESCRIPTION
## 背景
2.0.3 已让 Windows 窗口能显示,但**纯白、无首帧、控制台零输出**,且所有机器/所有版本均复现 → 引擎从未出帧,且 Dart 未抛异常(release 版会把未捕获异常打到控制台)。

## 本次
1. **补 `sqlite3_flutter_libs`**(确认缺失):桌面用 sqflite FFI 需要它打包 sqlite3 原生库,否则 Windows 开库失败(播放列表/收藏/持久化全废)。属确定 bug,无论白屏与否都要修。
2. **启动诊断日志**:release 版控制台不可靠,改在 `main()` 用 `runZonedGuarded` + `FlutterError.onError` + 首帧回调,把关键节点写到 `%TEMP%\xplayer_startup.log`:
   - `binding initialized` / `sqflite ffi init done` / `calling runApp` / `runApp returned`
   - `first frame built`(出现=Dart 成功构建了一帧 → 问题在 GPU/光栅présent;不出现=卡在更早或异常)
   - `FlutterError:` / `ZONE ERROR:`(任何异常堆栈)

据此可判定白屏是**渲染后端**还是**Dart 异常**,下一版精准修。

## 验证
- `flutter analyze` 0 errors;仅新增依赖 + main() 包裹,行为不变。