### PR TITLE
feat: 体验优化批次 + Issue 模板 + 新增开源直播源(自 2.0.4)

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug_report_zh.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug_report_zh.yml
@@ -1,0 +1,123 @@
+name: 🐛 Bug 报告(中文)
+description: 报告 XPlayer 遇到的 bug
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢提交 bug 报告!请填完下面所有 **必填** 项 —— 没有复现步骤的 issue 基本无法定位。
+
+        > 直播源里**个别频道打不开**多数是源本身失效,不一定是 App 的 bug:可先用右上角「测速」筛查,或换个频道/源验证。
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: 前置检查
+      options:
+        - label: 我已搜过 [已有 Issues](https://github.com/TNT-Likely/xplayer/issues?q=is%3Aissue),没有找到重复
+          required: true
+        - label: 我已升级到 [最新版本](https://github.com/TNT-Likely/xplayer/releases/latest),问题仍在
+          required: true
+        - label: 我确认这不是单个频道源失效的问题(已用其他频道/源验证)
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 问题描述
+      description: 一句话清晰说明你遇到了什么
+      placeholder: "例:切换到某频道后一直黑屏"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 复现步骤
+      description: 详细到别人照着做能复现的程度。至少 3 步,每步一行
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期望行为
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 实际行为
+      description: 出了什么具体现象。有闪退 / 报错请粘贴日志或截图
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: 平台
+      options:
+        - Android 手机 / 平板
+        - Android TV / 盒子
+        - iOS / iPad
+        - macOS
+        - Windows
+        - Linux
+    validations:
+      required: true
+
+  - type: input
+    id: app_version
+    attributes:
+      label: App 版本
+      description: 侧边栏顶部可见
+      placeholder: "例:2.0.5"
+    validations:
+      required: true
+
+  - type: input
+    id: os_version
+    attributes:
+      label: 系统版本
+      placeholder: "例:Android 14 / Windows 11 / iOS 18"
+    validations:
+      required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: 设备型号
+      placeholder: "例:小米电视 / Pixel 8 / ThinkPad"
+
+  - type: dropdown
+    id: source
+    attributes:
+      label: 直播源
+      description: 出问题时用的是什么源
+      options:
+        - 内置默认(中国)
+        - 内置其他推荐源(港 / 台 / 美 / 体育…)
+        - 自定义 M3U(网络 URL)
+        - 自定义 M3U(本地文件)
+        - 不确定
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: 日志 / 截图
+      description: |
+        截图可直接拖拽进来;有崩溃堆栈请一并贴上。
+        **敏感信息(自定义源地址里的 token 等)请自行打码**。
+      render: text
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 其他补充(非必填)

--- a/.github/ISSUE_TEMPLATE/02-feature_request_zh.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature_request_zh.yml
@@ -1,0 +1,78 @@
+name: ✨ 功能建议(中文)
+description: 提出新功能或改进建议
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢你的建议!**先说清楚要解决的"问题"比"方案"更重要** —— 这样我们能判断要不要做、怎么做最合适。
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: 前置检查
+      options:
+        - label: 我已搜过 [已有 Issues / Discussions](https://github.com/TNT-Likely/xplayer/issues?q=is%3Aissue),没有重复
+          required: true
+        - label: 本次请求只包含**一个独立功能**,不混杂多个不相关的模块
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: 遇到的问题 / 使用场景
+      description: 描述你现在的使用场景,遇到了什么不方便。**不要直接说"请加 XX 功能"**,先说问题
+      placeholder: |
+        例:
+        我常看的频道分散在不同源里,每次都要来回切换播放列表很麻烦。
+        希望能把不同源的频道合并到一个自定义分组里。
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: 期望的解决方案
+      description: 理想中它应该怎么工作
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 替代方案(非必填)
+      description: 你还考虑过哪些其他做法?为什么它们不够好?
+
+  - type: textarea
+    id: examples
+    attributes:
+      label: 参考示例(非必填)
+      description: 类似功能在其他 App 上的例子,截图也可以
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: 优先级
+      description: 这个功能对你有多重要?
+      options:
+        - 可有可无
+        - 有用但不紧急
+        - 很重要
+        - 非常关键
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: willingness
+    attributes:
+      label: 贡献意愿(可多选)
+      options:
+        - label: 我愿意提交 PR 实现此功能(先跟 maintainer 对齐方案再动手)
+        - label: 我可以帮助测试
+        - label: 我可以提供更详细的需求说明
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 其他补充(非必填)

--- a/.github/ISSUE_TEMPLATE/03-question_zh.yml
+++ b/.github/ISSUE_TEMPLATE/03-question_zh.yml
@@ -1,0 +1,64 @@
+name: ❓ 问题求助(中文)
+description: 使用过程中的疑问或需要帮助
+title: "[Question] "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > ⚠️ **求助类问题更推荐用 [Discussions](https://github.com/TNT-Likely/xplayer/discussions)** —— issue 跟踪 bug / feature,Discussions 更适合交流。
+        >
+        > 确实要开 issue 也可以,请按下面填清楚。
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: 前置检查
+      options:
+        - label: 我已看过 [README](https://github.com/TNT-Likely/xplayer#readme),没有找到答案
+          required: true
+        - label: 我已搜过 [Issues](https://github.com/TNT-Likely/xplayer/issues) 和 [Discussions](https://github.com/TNT-Likely/xplayer/discussions),没有找到相同问题
+          required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: 具体问题
+      description: 详细描述你想实现什么 + 遇到了什么困难
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: 问题分类
+      options:
+        - 直播源 / 订阅
+        - 频道播放
+        - 节目单 EPG
+        - 搜索 / 分组
+        - 收藏
+        - 检查更新 / 下载
+        - 手机遥控 TV
+        - 其他
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: 已经尝试过什么
+      description: 避免推荐你重复尝试的路径
+    validations:
+      required: true
+
+  - type: input
+    id: app_version
+    attributes:
+      label: App 版本
+      placeholder: "例:2.0.5"
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 其他补充(非必填)

--- a/.github/ISSUE_TEMPLATE/04-bug_report_en.yml
+++ b/.github/ISSUE_TEMPLATE/04-bug_report_en.yml
@@ -1,0 +1,123 @@
+name: 🐛 Bug Report (English)
+description: Report a bug in XPlayer
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! Please fill in all **required** fields — issues without repro steps are hard to act on.
+
+        > A **single channel failing to play** is usually a dead upstream source, not necessarily an app bug. Try the "test" button (top-right) or another channel/source first.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched [existing issues](https://github.com/TNT-Likely/xplayer/issues?q=is%3Aissue) and found no duplicate
+          required: true
+        - label: I'm on the [latest release](https://github.com/TNT-Likely/xplayer/releases/latest) and it still happens
+          required: true
+        - label: I confirmed this isn't just one dead channel/source (verified with others)
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: One clear sentence on what went wrong
+      placeholder: "e.g. Black screen forever after switching to a channel"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Detailed enough for someone else to reproduce. At least 3 steps, one per line
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened. Paste crash logs / screenshots if any
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Android phone / tablet
+        - Android TV / box
+        - iOS / iPad
+        - macOS
+        - Windows
+        - Linux
+    validations:
+      required: true
+
+  - type: input
+    id: app_version
+    attributes:
+      label: App version
+      description: Shown at the top of the side drawer
+      placeholder: "e.g. 2.0.5"
+    validations:
+      required: true
+
+  - type: input
+    id: os_version
+    attributes:
+      label: OS version
+      placeholder: "e.g. Android 14 / Windows 11 / iOS 18"
+    validations:
+      required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: Device model
+      placeholder: "e.g. Xiaomi TV / Pixel 8 / ThinkPad"
+
+  - type: dropdown
+    id: source
+    attributes:
+      label: Source
+      description: Which playlist was in use
+      options:
+        - Built-in default (China)
+        - Built-in preset (HK / TW / US / Sports…)
+        - Custom M3U (URL)
+        - Custom M3U (local file)
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: |
+        Drag in screenshots; paste crash stack traces if any.
+        **Redact sensitive info** (tokens in custom source URLs, etc.).
+      render: text
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context (optional)

--- a/.github/ISSUE_TEMPLATE/05-feature_request_en.yml
+++ b/.github/ISSUE_TEMPLATE/05-feature_request_en.yml
@@ -1,0 +1,79 @@
+name: ✨ Feature Request (English)
+description: Suggest a new feature or improvement
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! **Describing the "problem" matters more than the "solution"** — it helps us decide whether and how to build it.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched [existing issues / discussions](https://github.com/TNT-Likely/xplayer/issues?q=is%3Aissue) and found no duplicate
+          required: true
+        - label: This request covers **one self-contained feature**, not several unrelated ones
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: Describe your current workflow and what's inconvenient. **Don't just say "add X"** — describe the problem first
+      placeholder: |
+        e.g.
+        My favorite channels are spread across different sources, and switching
+        playlists back and forth is tedious. I'd like to merge channels from
+        different sources into one custom group.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How it should ideally work
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives (optional)
+      description: What else did you consider, and why isn't it good enough?
+
+  - type: textarea
+    id: examples
+    attributes:
+      label: References (optional)
+      description: Examples of similar features in other apps; screenshots welcome
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is this to you?
+      options:
+        - Nice to have
+        - Useful but not urgent
+        - Important
+        - Critical
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: willingness
+    attributes:
+      label: Contribution (multiple allowed)
+      options:
+        - label: I'm willing to submit a PR (after aligning the approach with the maintainer)
+        - label: I can help test
+        - label: I can provide more detailed requirements
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context (optional)

--- a/.github/ISSUE_TEMPLATE/06-question_en.yml
+++ b/.github/ISSUE_TEMPLATE/06-question_en.yml
@@ -1,0 +1,64 @@
+name: ❓ Question (English)
+description: A question or help needed while using XPlayer
+title: "[Question] "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > ⚠️ **For help, prefer [Discussions](https://github.com/TNT-Likely/xplayer/discussions)** — issues track bugs / features; Discussions are better for Q&A.
+        >
+        > If you still want an issue, please fill in the details below.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I read the [README](https://github.com/TNT-Likely/xplayer#readme) and didn't find the answer
+          required: true
+        - label: I searched [Issues](https://github.com/TNT-Likely/xplayer/issues) and [Discussions](https://github.com/TNT-Likely/xplayer/discussions) and found nothing matching
+          required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: Describe what you're trying to do and where you're stuck
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - Sources / subscriptions
+        - Channel playback
+        - EPG (programme guide)
+        - Search / grouping
+        - Favorites
+        - Updates / downloads
+        - Phone-to-TV remote
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What you've tried
+      description: So we don't suggest paths you already tried
+    validations:
+      required: true
+
+  - type: input
+    id: app_version
+    attributes:
+      label: App version
+      placeholder: "e.g. 2.0.5"
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context (optional)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📖 使用说明 / README
+    url: https://github.com/TNT-Likely/xplayer#readme
+    about: 先看 README 的特性与使用说明。Check the README for features and usage first.
+  - name: 💬 讨论区 / Discussions
+    url: https://github.com/TNT-Likely/xplayer/discussions
+    about: 使用交流、非 bug 求助请用 Discussions(需仓库已开启)。Use Discussions for Q&A and non-bug help (if enabled).
+  - name: 📺 直播源来自 iptv-org / Upstream sources
+    url: https://github.com/iptv-org/iptv
+    about: 内置源来自 iptv-org;某条频道失效多为上游问题,请到 iptv-org 反馈。Built-in sources come from iptv-org; dead channels are usually upstream.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 <p align="center">开箱即用，内置 <a href="https://github.com/iptv-org/iptv">iptv-org</a> 公开直播源，支持<b>频道分组、搜索</b>、EPG 节目单、收藏，以及<b>手机遥控 TV 输入</b>。</p>
 
+<p align="center">
+  <a href="https://github.com/TNT-Likely/xplayer/releases/latest"><img src="https://img.shields.io/github/v/release/TNT-Likely/xplayer?style=flat-square&color=brightgreen" alt="最新版本"></a>
+  <a href="https://github.com/TNT-Likely/xplayer/releases"><img src="https://img.shields.io/github/downloads/TNT-Likely/xplayer/total?style=flat-square&color=blue" alt="下载量"></a>
+  <a href="https://github.com/TNT-Likely/xplayer/stargazers"><img src="https://img.shields.io/github/stars/TNT-Likely/xplayer?style=flat-square" alt="Stars"></a>
+  <a href="https://github.com/TNT-Likely/xplayer/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/TNT-Likely/xplayer/release.yml?style=flat-square&label=release" alt="构建状态"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/TNT-Likely/xplayer?style=flat-square" alt="License"></a>
+</p>
+
 ---
 
 ## ✨ 特性

--- a/README_EN.md
+++ b/README_EN.md
@@ -6,6 +6,14 @@
 
 <p align="center">Works out of the box with built-in <a href="https://github.com/iptv-org/iptv">iptv-org</a> public playlists, with <b>channel grouping &amp; search</b>, EPG, favorites, and <b>phone-to-TV remote text input</b>.</p>
 
+<p align="center">
+  <a href="https://github.com/TNT-Likely/xplayer/releases/latest"><img src="https://img.shields.io/github/v/release/TNT-Likely/xplayer?style=flat-square&color=brightgreen" alt="Latest release"></a>
+  <a href="https://github.com/TNT-Likely/xplayer/releases"><img src="https://img.shields.io/github/downloads/TNT-Likely/xplayer/total?style=flat-square&color=blue" alt="Total downloads"></a>
+  <a href="https://github.com/TNT-Likely/xplayer/stargazers"><img src="https://img.shields.io/github/stars/TNT-Likely/xplayer?style=flat-square" alt="Stars"></a>
+  <a href="https://github.com/TNT-Likely/xplayer/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/TNT-Likely/xplayer/release.yml?style=flat-square&label=release" alt="Release build"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/TNT-Likely/xplayer?style=flat-square" alt="License"></a>
+</p>
+
 ---
 
 ## ✨ Features

--- a/lib/data/models/channel_model.dart
+++ b/lib/data/models/channel_model.dart
@@ -114,10 +114,22 @@ Map<String, String> _parseAttributes(String? attributesString) {
 }
 
 List<Channel> parseChannels(String jsonString) {
+  if (jsonString.trim().isEmpty) return [];
   try {
-    final Map<String, dynamic> data = json.decode(jsonString);
-    final List<dynamic> channelsJson = data['items'] ?? [];
-    return channelsJson.map((json) => Channel.fromJson(json)).toList();
+    final decoded = json.decode(jsonString);
+    // 缓存实际格式是 jsonEncode(toChannels()) —— 一个数组;
+    // 同时兼容 {items:[...]} / {channels:[...]} 的对象格式。
+    final List<dynamic> channelsJson;
+    if (decoded is List) {
+      channelsJson = decoded;
+    } else if (decoded is Map<String, dynamic>) {
+      channelsJson = (decoded['items'] ?? decoded['channels'] ?? []) as List;
+    } else {
+      channelsJson = [];
+    }
+    return channelsJson
+        .map((json) => Channel.fromJson(json as Map<String, dynamic>))
+        .toList();
   } catch (err) {
     print('Error parsing JSON: $err');
     return [];

--- a/lib/data/models/iptv_presets.dart
+++ b/lib/data/models/iptv_presets.dart
@@ -46,4 +46,26 @@ const List<IptvPreset> kIptvPresets = [
   IptvPreset(nameKey: 'presetSports', fallbackName: '体育 Sports', url: '$_base/categories/sports.m3u'),
   IptvPreset(nameKey: 'presetNews', fallbackName: '新闻 News', url: '$_base/categories/news.m3u'),
   IptvPreset(nameKey: 'presetMovies', fallbackName: '电影 Movies', url: '$_base/categories/movies.m3u'),
+  // 其他开源直播源项目(同样运行时拉取、仅聚合公开流,可随时删除)。
+  // 质量/合规参差,IPv6 源需要 IPv6 网络;名字带项目名便于溯源。
+  IptvPreset(
+      nameKey: 'presetFreeTv',
+      fallbackName: 'Free-TV · 全球 Global',
+      url: 'https://raw.githubusercontent.com/Free-TV/IPTV/master/playlist.m3u8'),
+  IptvPreset(
+      nameKey: 'presetVbskycn',
+      fallbackName: 'vbskycn · 国内 China',
+      url: 'https://raw.githubusercontent.com/vbskycn/iptv/master/tv/iptv4.m3u'),
+  IptvPreset(
+      nameKey: 'presetYueChan',
+      fallbackName: 'YueChan · 国内外 CN+Intl',
+      url: 'https://raw.githubusercontent.com/YueChan/Live/main/IPTV.m3u'),
+  IptvPreset(
+      nameKey: 'presetFanmingming',
+      fallbackName: '央视卫视 CCTV · IPv6',
+      url: 'https://live.fanmingming.com/tv/m3u/ipv6.m3u'),
+  IptvPreset(
+      nameKey: 'presetJoevess',
+      fallbackName: 'joevess · 优选 Curated',
+      url: 'https://raw.githubusercontent.com/joevess/IPTV/main/home.m3u8'),
 ];

--- a/lib/localization/app_en.arb
+++ b/lib/localization/app_en.arb
@@ -124,5 +124,11 @@
   "exitAppTitle": "Exit App",
   "exitAppMessage": "Are you sure you want to exit?",
   "exit": "Exit",
-  "retry": "Retry"
+  "retry": "Retry",
+  "operationHints": "Controls",
+  "hintSwitchChannel": "Switch channel: ↑↓ or swipe up/down",
+  "hintChannelList": "Channel list: ← or swipe left",
+  "hintSwitchSource": "Switch source: → or swipe right",
+  "hintMenu": "Menu: OK or tap screen",
+  "hintGotIt": "Got it"
 }

--- a/lib/localization/app_en.arb
+++ b/lib/localization/app_en.arb
@@ -130,5 +130,6 @@
   "hintChannelList": "Channel list: ← or swipe left",
   "hintSwitchSource": "Switch source: → or swipe right",
   "hintMenu": "Menu: OK or tap screen",
-  "hintGotIt": "Got it"
+  "hintGotIt": "Got it",
+  "hideUnplayable": "Hide unplayable"
 }

--- a/lib/localization/app_en.arb
+++ b/lib/localization/app_en.arb
@@ -131,5 +131,6 @@
   "hintSwitchSource": "Switch source: → or swipe right",
   "hintMenu": "Menu: OK or tap screen",
   "hintGotIt": "Got it",
-  "hideUnplayable": "Hide unplayable"
+  "hideUnplayable": "Hide unplayable",
+  "autoRefreshOnLaunch": "Auto-update on launch"
 }

--- a/lib/localization/app_en.arb
+++ b/lib/localization/app_en.arb
@@ -111,7 +111,7 @@
   "presetSports": "Sports",
   "presetNews": "News",
   "presetAll": "All Channels",
-  "presetDisclaimer": "Channels come from the public iptv-org list (aggregation only) and can be removed anytime.",
+  "presetDisclaimer": "Channels come from public open-source IPTV projects (aggregation only) and can be removed anytime.",
   "search": "Search",
   "searchChannelsHint": "Search channel name",
   "allGroups": "All",

--- a/lib/localization/app_en.arb
+++ b/lib/localization/app_en.arb
@@ -123,5 +123,6 @@
   "noProgramme": "No programme guide for this channel",
   "exitAppTitle": "Exit App",
   "exitAppMessage": "Are you sure you want to exit?",
-  "exit": "Exit"
+  "exit": "Exit",
+  "retry": "Retry"
 }

--- a/lib/localization/app_en.arb
+++ b/lib/localization/app_en.arb
@@ -120,5 +120,8 @@
   "updateProxyHint": "Route update downloads through this HTTP proxy (host:port) to speed them up; empty = direct. Updates only — playback is unaffected.",
   "filterTitle": "Search & Filter",
   "itemSize": "Item Size",
-  "noProgramme": "No programme guide for this channel"
+  "noProgramme": "No programme guide for this channel",
+  "exitAppTitle": "Exit App",
+  "exitAppMessage": "Are you sure you want to exit?",
+  "exit": "Exit"
 }

--- a/lib/localization/app_zh.arb
+++ b/lib/localization/app_zh.arb
@@ -123,5 +123,6 @@
     "noProgramme": "该频道暂无节目单",
     "exitAppTitle": "退出应用",
     "exitAppMessage": "确定要退出应用吗？",
-    "exit": "退出"
+    "exit": "退出",
+    "retry": "重试"
 }

--- a/lib/localization/app_zh.arb
+++ b/lib/localization/app_zh.arb
@@ -131,5 +131,6 @@
     "hintSwitchSource": "切换源：→ 键 或 右滑",
     "hintMenu": "呼出菜单：OK 键 或 单击屏幕",
     "hintGotIt": "知道了",
-    "hideUnplayable": "隐藏无法播放"
+    "hideUnplayable": "隐藏无法播放",
+    "autoRefreshOnLaunch": "启动时自动更新"
 }

--- a/lib/localization/app_zh.arb
+++ b/lib/localization/app_zh.arb
@@ -130,5 +130,6 @@
     "hintChannelList": "频道列表：← 键 或 左滑",
     "hintSwitchSource": "切换源：→ 键 或 右滑",
     "hintMenu": "呼出菜单：OK 键 或 单击屏幕",
-    "hintGotIt": "知道了"
+    "hintGotIt": "知道了",
+    "hideUnplayable": "隐藏无法播放"
 }

--- a/lib/localization/app_zh.arb
+++ b/lib/localization/app_zh.arb
@@ -120,5 +120,8 @@
     "updateProxyHint": "在线更新走此 HTTP 代理（host:port），加速下载；留空直连。仅用于更新，不影响播放。",
     "filterTitle": "搜索与筛选",
     "itemSize": "显示大小",
-    "noProgramme": "该频道暂无节目单"
+    "noProgramme": "该频道暂无节目单",
+    "exitAppTitle": "退出应用",
+    "exitAppMessage": "确定要退出应用吗？",
+    "exit": "退出"
 }

--- a/lib/localization/app_zh.arb
+++ b/lib/localization/app_zh.arb
@@ -124,5 +124,11 @@
     "exitAppTitle": "退出应用",
     "exitAppMessage": "确定要退出应用吗？",
     "exit": "退出",
-    "retry": "重试"
+    "retry": "重试",
+    "operationHints": "操作说明",
+    "hintSwitchChannel": "切换频道：↑↓ 键 或 上下滑动",
+    "hintChannelList": "频道列表：← 键 或 左滑",
+    "hintSwitchSource": "切换源：→ 键 或 右滑",
+    "hintMenu": "呼出菜单：OK 键 或 单击屏幕",
+    "hintGotIt": "知道了"
 }

--- a/lib/localization/app_zh.arb
+++ b/lib/localization/app_zh.arb
@@ -111,7 +111,7 @@
     "presetSports": "体育",
     "presetNews": "新闻",
     "presetAll": "全部频道",
-    "presetDisclaimer": "直播源来自 iptv-org 公开列表，仅做聚合，可随时删除。",
+    "presetDisclaimer": "直播源来自公开的开源直播源项目，仅做聚合，可随时删除。",
     "search": "搜索",
     "searchChannelsHint": "搜索频道名称",
     "allGroups": "全部",

--- a/lib/presentation/screens/home.dart
+++ b/lib/presentation/screens/home.dart
@@ -15,6 +15,7 @@ import 'package:xplayer/presentation/widgets/update_proxy_dialog.dart';
 import 'package:xplayer/shared/components/x_text_button.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:xplayer/providers/locale_provider.dart';
+import 'package:flutter/services.dart';
 import 'package:xplayer/shared/components/x_icon_button.dart';
 import 'package:xplayer/shared/theme/app_tokens.dart';
 import 'package:xplayer/utils/dialog.dart';
@@ -207,8 +208,55 @@ class _HomeScreenState extends State<HomeScreen> {
     };
   }
 
+  /// 返回键退出二次确认(App 与 TV 共用系统返回键)。
+  /// 抽屉打开时优先关抽屉,不弹退出框。
+  Future<bool> _confirmExit(BuildContext context) async {
+    final l = AppLocalizations.of(context)!;
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: AppTokens.surfacePanel,
+        title: Text(l.exitAppTitle,
+            style: const TextStyle(color: AppTokens.textPrimary)),
+        content: Text(l.exitAppMessage,
+            style: const TextStyle(color: AppTokens.textSecondary)),
+        actions: [
+          XTextButton(
+            text: l.cancel,
+            onPressed: () => Navigator.of(ctx).pop(false),
+          ),
+          XTextButton(
+            text: l.exit,
+            type: XTextButtonType.danger,
+            onPressed: () => Navigator.of(ctx).pop(true),
+          ),
+        ],
+      ),
+    );
+    return result ?? false;
+  }
+
   @override
   Widget build(BuildContext context) {
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) async {
+        if (didPop) return;
+        // 抽屉开着先关抽屉
+        final scaffold = _scaffoldKey.currentState;
+        if (scaffold != null && scaffold.isDrawerOpen) {
+          scaffold.closeDrawer();
+          return;
+        }
+        if (await _confirmExit(context)) {
+          await SystemNavigator.pop();
+        }
+      },
+      child: _buildHome(context),
+    );
+  }
+
+  Widget _buildHome(BuildContext context) {
     final localeProvider = Provider.of<LocaleProvider>(context, listen: false);
     final localizations = AppLocalizations.of(context)!;
 

--- a/lib/presentation/screens/home.dart
+++ b/lib/presentation/screens/home.dart
@@ -374,6 +374,47 @@ class _HomeScreenState extends State<HomeScreen> {
             child: ListView(
               padding: EdgeInsets.zero,
               children: <Widget>[
+                // 顶部品牌头:logo + 名称 + 版本
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 20, 16, 12),
+                  child: Row(
+                    children: [
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: Image.asset(
+                          'assets/images/mini-logo.png',
+                          width: 40,
+                          height: 40,
+                          fit: BoxFit.cover,
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const Text(
+                              'XPlayer',
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontSize: 20,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                            Text(
+                              _version,
+                              style: const TextStyle(
+                                color: Colors.white54,
+                                fontSize: 12,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const Divider(color: Colors.white24, height: 1),
                 Consumer<MediaProvider>(
                   builder: (BuildContext context2, mediaProvider, _) {
                     final playlist = [
@@ -431,7 +472,7 @@ class _HomeScreenState extends State<HomeScreen> {
                     );
                   },
                 ),
-                // 远程输入菜单：仅在手机端显示，放在播放列表之后
+                const Divider(color: Colors.white12, height: 8),
                 XBaseButton(
                   child: animeContainer(
                     ListTile(
@@ -488,6 +529,7 @@ class _HomeScreenState extends State<HomeScreen> {
                     }
                   },
                 ),
+                const Divider(color: Colors.white12, height: 8),
                 XBaseButton(
                   onPressed: () {
                     Navigator.push(
@@ -526,6 +568,7 @@ class _HomeScreenState extends State<HomeScreen> {
                     ),
                   ),
                 ),
+                const Divider(color: Colors.white12, height: 8),
                 Consumer<GlobalProvider>(builder: (context, g, _) {
                   if (g.isTV) return const SizedBox.shrink();
                   return XBaseButton(
@@ -611,10 +654,6 @@ class _HomeScreenState extends State<HomeScreen> {
                       ),
                     ),
                   ),
-                ),
-                ListTile(
-                  leading: const Icon(Icons.info, color: Colors.white),
-                  title: Text(_version, style: const TextStyle(color: Colors.white)),
                 ),
               ],
             ),

--- a/lib/presentation/screens/home.dart
+++ b/lib/presentation/screens/home.dart
@@ -655,6 +655,26 @@ class _HomeScreenState extends State<HomeScreen> {
                     ),
                   ),
                 ),
+                Consumer<MediaProvider>(
+                  builder: (context, mp, _) => XBaseButton(
+                    onPressed: () =>
+                        mp.setAutoRefreshOnLaunch(!mp.autoRefreshOnLaunch),
+                    child: animeContainer(
+                      ListTile(
+                        leading:
+                            const Icon(Icons.autorenew, color: Colors.white),
+                        title: Text(
+                          localizations.autoRefreshOnLaunch,
+                          style: const TextStyle(color: Colors.white),
+                        ),
+                        trailing: Switch(
+                          value: mp.autoRefreshOnLaunch,
+                          onChanged: mp.setAutoRefreshOnLaunch,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
               ],
             ),
           ),

--- a/lib/presentation/screens/home.dart
+++ b/lib/presentation/screens/home.dart
@@ -320,6 +320,16 @@ class _HomeScreenState extends State<HomeScreen> {
                       active: false,
                       onPressed: () => _showSizeDialog(context),
                     ),
+                    // 测速后才出现:隐藏无法播放的频道(可恢复)
+                    if (mp.hasTestResults)
+                      _filterIcon(
+                        context,
+                        icon: Icons.playlist_remove,
+                        tooltip: localizations.hideUnplayable,
+                        active: mp.hideUnplayable,
+                        onPressed: () =>
+                            mp.setHideUnplayable(!mp.hideUnplayable),
+                      ),
                   ],
                 );
               },

--- a/lib/presentation/screens/home.dart
+++ b/lib/presentation/screens/home.dart
@@ -736,6 +736,25 @@ class _HomeScreenState extends State<HomeScreen> {
                           localizations.noChannelsFound,
                           style: const TextStyle(color: Colors.white),
                         ),
+                        const SizedBox(height: 16.0),
+                        SizedBox(
+                          width: 200,
+                          child: XTextButton(
+                            text: localizations.refreshChannels,
+                            type: XTextButtonType.primary,
+                            onPressed: () async {
+                              try {
+                                showToast(localizations.updatingChannels);
+                                await mediaProvider.refreshChannels();
+                                showToast(
+                                    localizations.channelsUpdatedSuccessfully);
+                              } catch (e) {
+                                showToast(localizations
+                                    .channelsUpdateFailed(e.toString()));
+                              }
+                            },
+                          ),
+                        ),
                       ],
                     ),
                   );

--- a/lib/presentation/screens/player.dart
+++ b/lib/presentation/screens/player.dart
@@ -46,6 +46,7 @@ class _PlayerScreenState extends State<PlayerScreen>
   int _bufferingRetryTimes = 0;
   Timer? _bufferingTimer;
   bool _isHandlingBuffering = false;
+  bool _isHandlingError = false;
 
   PlayState _playState = PlayState.idle;
 
@@ -114,7 +115,14 @@ class _PlayerScreenState extends State<PlayerScreen>
     super.dispose();
   }
 
-  Future<void> _initializePlayer() async {
+  Future<void> _initializePlayer({bool fresh = true}) async {
+    if (fresh) {
+      // 用户主动加载(首次/切台/换源/手动重试):重置重试计数
+      _retryTimes = 0;
+      _bufferingRetryTimes = 0;
+    }
+    _isHandlingError = false; // 新一轮加载,允许下次错误被处理
+
     try {
       _controller.pause();
       await _controller.dispose();
@@ -132,25 +140,44 @@ class _PlayerScreenState extends State<PlayerScreen>
       _controller.addListener(_listenToVideoController);
 
       await _controller.initialize().then((_) {
-        _retryTimes = 0;
-        _bufferingRetryTimes = 0;
         _controller.play();
         setState(() {
           // 初始化成功后更新状态为 playing
           _playState = PlayState.playing;
         });
       }).catchError((error) {
+        // 初始化失败:计入重试,超上限才 failed(统一走 _handleLoadError)
         Logger.debug('初始化播放器失败: $error');
-        // showToast('初始化播放器失败1: $error', duration: const Duration(minutes: 2));
-        setState(() {
-          // 初始化失败更新状态为 failed
-          _playState = PlayState.failed;
-        });
+        if (!_isHandlingError) {
+          _isHandlingError = true;
+          _handleLoadError();
+        }
       });
     } catch (e) {
       Logger.error('创建新播放器控制器失败: $e');
+      if (!_isHandlingError) {
+        _isHandlingError = true;
+        _handleLoadError();
+      }
+    }
+  }
+
+  /// 加载/播放错误统一处理:[_retryTimes] 上限内重载,超限停在失败页。
+  /// 关键:重试不重置计数(成功初始化但播放失败的源不会无限循环),
+  /// 因此最终一定能到失败页,而不是一直"加载中"。
+  void _handleLoadError() {
+    if (!mounted) return;
+    if (_retryTimes < 3) {
+      _retryTimes += 1;
       setState(() {
-        // 创建控制器失败更新状态为 failed
+        _playState = PlayState.retrying;
+      });
+      Timer(const Duration(milliseconds: 700), () {
+        if (!mounted) return;
+        _initializePlayer(fresh: false);
+      });
+    } else {
+      setState(() {
         _playState = PlayState.failed;
       });
     }
@@ -195,6 +222,11 @@ class _PlayerScreenState extends State<PlayerScreen>
       _bufferingTimer?.cancel();
       _isHandlingBuffering = false;
       _bufferingRetryTimes = 0;
+      if (value.isPlaying && !value.hasError) {
+        // 真正在播放:重置错误重试计数,允许后续偶发错误重新重试
+        _retryTimes = 0;
+        _isHandlingError = false;
+      }
       if (_playState == PlayState.buffering) {
         setState(() {
           // 缓冲结束更新状态为 playing
@@ -205,27 +237,10 @@ class _PlayerScreenState extends State<PlayerScreen>
 
     if (value.hasError) {
       Logger.debug('视频播放出现错误: ${value.errorDescription}');
-      if (_retryTimes < 3) {
-        _retryTimes += 1;
-        Timer(const Duration(milliseconds: 700), () {
-          setState(() {
-            // 出现错误且重试次数小于 3 时更新状态为 retrying
-            _playState = PlayState.retrying;
-          });
-          _initializePlayer().then((value) {
-            setState(() {
-              // 重试后根据播放状态更新状态
-              _playState = _controller.value.isPlaying
-                  ? PlayState.playing
-                  : PlayState.paused;
-            });
-          });
-        });
-      } else {
-        setState(() {
-          // 错误次数超过 3 次更新状态为 failed
-          _playState = PlayState.failed;
-        });
+      // 每次错误只处理一次,避免监听器重复触发导致计数瞬间打满/并发重载
+      if (!_isHandlingError) {
+        _isHandlingError = true;
+        _handleLoadError();
       }
     } else if (!value.isPlaying && !value.isBuffering) {
       Logger.debug('视频暂停');
@@ -495,8 +510,6 @@ class _PlayerScreenState extends State<PlayerScreen>
                               text: AppLocalizations.of(context)!.retry,
                               type: XTextButtonType.primary,
                               onPressed: () {
-                                _retryTimes = 0;
-                                _bufferingRetryTimes = 0;
                                 _initializePlayer();
                               },
                             ),

--- a/lib/presentation/screens/player.dart
+++ b/lib/presentation/screens/player.dart
@@ -7,6 +7,7 @@ import 'package:xplayer/data/models/channel_model.dart';
 import 'package:xplayer/data/models/programme_model.dart';
 import 'package:xplayer/presentation/widgets/player_actions_widget.dart';
 import 'package:xplayer/presentation/widgets/player_dialogs.dart';
+import 'package:xplayer/shared/components/x_text_button.dart';
 import 'package:xplayer/providers/media_provider.dart';
 import 'package:xplayer/utils/logger_util.dart';
 import 'package:xplayer/utils/playlist_util.dart';
@@ -40,6 +41,7 @@ class _PlayerScreenState extends State<PlayerScreen>
   late String _sourceLink;
   Timer? autoCloseTimer;
   int _retryTimes = 0;
+  int _bufferingRetryTimes = 0;
   Timer? _bufferingTimer;
   bool _isHandlingBuffering = false;
 
@@ -116,6 +118,7 @@ class _PlayerScreenState extends State<PlayerScreen>
 
       await _controller.initialize().then((_) {
         _retryTimes = 0;
+        _bufferingRetryTimes = 0;
         _controller.play();
         setState(() {
           // 初始化成功后更新状态为 playing
@@ -148,14 +151,23 @@ class _PlayerScreenState extends State<PlayerScreen>
         _bufferingTimer?.cancel();
         _bufferingTimer = Timer(const Duration(seconds: 5), () {
           if (_controller.value.isBuffering) {
-            Logger.debug('长时间缓冲，尝试重新加载...');
-            _controller.pause();
-            _controller.seekTo(Duration.zero);
-            _controller.play();
-            setState(() {
-              // 长时间缓冲更新状态为 retrying
-              _playState = PlayState.retrying;
-            });
+            if (_bufferingRetryTimes < 3) {
+              _bufferingRetryTimes += 1;
+              Logger.debug('长时间缓冲，尝试重新加载...($_bufferingRetryTimes/3)');
+              _controller.pause();
+              _controller.seekTo(Duration.zero);
+              _controller.play();
+              setState(() {
+                // 长时间缓冲更新状态为 retrying
+                _playState = PlayState.retrying;
+              });
+            } else {
+              // 长缓冲重试已达上限,不再无限重载,直接标记失败
+              Logger.debug('长缓冲重试已达上限,标记失败');
+              setState(() {
+                _playState = PlayState.failed;
+              });
+            }
           }
           _isHandlingBuffering = false;
         });
@@ -167,6 +179,7 @@ class _PlayerScreenState extends State<PlayerScreen>
     } else {
       _bufferingTimer?.cancel();
       _isHandlingBuffering = false;
+      _bufferingRetryTimes = 0;
       if (_playState == PlayState.buffering) {
         setState(() {
           // 缓冲结束更新状态为 playing
@@ -451,11 +464,33 @@ class _PlayerScreenState extends State<PlayerScreen>
                         const Icon(
                           Icons.cloud_off,
                           color: Colors.white,
-                          size: 100,
+                          size: 80,
                         ),
+                        const SizedBox(height: 12),
                         Text(
                           AppLocalizations.of(context)!.loadingFailed,
-                          style: const TextStyle(color: Colors.white),
+                          style: const TextStyle(
+                              color: Colors.white, fontSize: 16),
+                        ),
+                        const SizedBox(height: 20),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            XTextButton(
+                              text: AppLocalizations.of(context)!.retry,
+                              type: XTextButtonType.primary,
+                              onPressed: () {
+                                _retryTimes = 0;
+                                _bufferingRetryTimes = 0;
+                                _initializePlayer();
+                              },
+                            ),
+                            const SizedBox(width: 16),
+                            XTextButton(
+                              text: AppLocalizations.of(context)!.back,
+                              onPressed: () => Navigator.of(context).pop(),
+                            ),
+                          ],
                         ),
                       ],
                     ),
@@ -475,10 +510,26 @@ class _PlayerScreenState extends State<PlayerScreen>
                       ],
                     ),
                   )
-                else
+                else if (_controller.value.isInitialized &&
+                    _controller.value.aspectRatio > 0)
                   AspectRatio(
                     aspectRatio: _controller.value.aspectRatio,
                     child: VideoPlayer(_controller),
+                  )
+                else
+                  // 控制器尚未就绪时显示加载,避免渲染未初始化播放器导致黑屏空白
+                  Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        const CircularProgressIndicator(),
+                        const SizedBox(height: 16),
+                        Text(
+                          AppLocalizations.of(context)!.loading,
+                          style: const TextStyle(color: Colors.white),
+                        ),
+                      ],
+                    ),
                   ),
                 if (_playState == PlayState.buffering)
                   Positioned.fill(

--- a/lib/presentation/screens/player.dart
+++ b/lib/presentation/screens/player.dart
@@ -7,7 +7,9 @@ import 'package:xplayer/data/models/channel_model.dart';
 import 'package:xplayer/data/models/programme_model.dart';
 import 'package:xplayer/presentation/widgets/player_actions_widget.dart';
 import 'package:xplayer/presentation/widgets/player_dialogs.dart';
+import 'package:xplayer/presentation/widgets/operation_hint_dialog.dart';
 import 'package:xplayer/shared/components/x_text_button.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:xplayer/providers/media_provider.dart';
 import 'package:xplayer/utils/logger_util.dart';
 import 'package:xplayer/utils/playlist_util.dart';
@@ -79,6 +81,19 @@ class _PlayerScreenState extends State<PlayerScreen>
 
     _initializePlayer();
     _focusNode.requestFocus();
+
+    // 首次进入播放页弹一次操作引导(看过后不再弹,可从控制条「帮助」再看)
+    WidgetsBinding.instance
+        .addPostFrameCallback((_) => _maybeShowOperationHint());
+  }
+
+  Future<void> _maybeShowOperationHint() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (prefs.getBool('player_hint_seen') ?? false) return;
+    if (!mounted) return;
+    await OperationHintDialog.show(context);
+    await prefs.setBool('player_hint_seen', true);
+    if (mounted) _focusNode.requestFocus(); // 关闭引导后把焦点还给播放器
   }
 
   @override

--- a/lib/presentation/screens/splash.dart
+++ b/lib/presentation/screens/splash.dart
@@ -16,7 +16,10 @@ class _SplashScreenState extends State<SplashScreen> {
   @override
   void initState() {
     super.initState();
-    _initializeAndNavigate();
+    // 放到首帧之后再初始化:initializeApp 起步就会 notifyListeners,
+    // 若在 initState 同步触发会报 "setState() called during build"。
+    WidgetsBinding.instance
+        .addPostFrameCallback((_) => _initializeAndNavigate());
   }
 
   void _initializeAndNavigate() async {

--- a/lib/presentation/widgets/operation_hint_dialog.dart
+++ b/lib/presentation/widgets/operation_hint_dialog.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:xplayer/shared/components/x_text_button.dart';
+import 'package:xplayer/shared/theme/app_tokens.dart';
+
+/// 播放页操作引导:首次进入弹一次,之后可从控制条「帮助」再次打开。
+/// 每行文案同时覆盖遥控按键与触屏手势,一套适配 TV 与手机。
+class OperationHintDialog extends StatelessWidget {
+  const OperationHintDialog({super.key});
+
+  static Future<void> show(BuildContext context) {
+    return showDialog<void>(
+      context: context,
+      builder: (_) => const OperationHintDialog(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context)!;
+    return AlertDialog(
+      backgroundColor: AppTokens.surfacePanel,
+      title: Text(l.operationHints,
+          style: const TextStyle(color: AppTokens.textPrimary)),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _row(Icons.swap_vert, l.hintSwitchChannel),
+          _row(Icons.format_list_bulleted, l.hintChannelList),
+          _row(Icons.swap_horiz, l.hintSwitchSource),
+          _row(Icons.menu, l.hintMenu),
+        ],
+      ),
+      actions: [
+        XTextButton(
+          text: l.hintGotIt,
+          type: XTextButtonType.primary,
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ],
+    );
+  }
+
+  Widget _row(IconData icon, String label) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        children: [
+          Icon(icon, color: AppTokens.brand, size: 22),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Text(
+              label,
+              style: const TextStyle(color: AppTokens.textSecondary, fontSize: 15),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/player_actions_widget.dart
+++ b/lib/presentation/widgets/player_actions_widget.dart
@@ -10,7 +10,6 @@ import 'package:xplayer/data/models/programme_model.dart';
 import 'package:xplayer/providers/global_provider.dart';
 import 'package:xplayer/shared/components/x_base_button.dart';
 import 'package:xplayer/shared/components/x_icon_button.dart';
-import 'package:xplayer/presentation/widgets/operation_hint_dialog.dart';
 import 'package:xplayer/providers/media_provider.dart';
 import 'package:xplayer/utils/playlist_util.dart';
 import 'package:flutter/services.dart';
@@ -254,11 +253,6 @@ class _PlayerActionsWidgetState extends State<PlayerActionsWidget>
                         widget.onProgramme!();
                       }
                     },
-                  ),
-                  const SizedBox(width: 8),
-                  XIconButton(
-                    icon: Icons.help_outline,
-                    onPressed: () => OperationHintDialog.show(context),
                   ),
                   const SizedBox(width: 8),
                   XIconButton(

--- a/lib/presentation/widgets/player_actions_widget.dart
+++ b/lib/presentation/widgets/player_actions_widget.dart
@@ -10,6 +10,7 @@ import 'package:xplayer/data/models/programme_model.dart';
 import 'package:xplayer/providers/global_provider.dart';
 import 'package:xplayer/shared/components/x_base_button.dart';
 import 'package:xplayer/shared/components/x_icon_button.dart';
+import 'package:xplayer/presentation/widgets/operation_hint_dialog.dart';
 import 'package:xplayer/providers/media_provider.dart';
 import 'package:xplayer/utils/playlist_util.dart';
 import 'package:flutter/services.dart';
@@ -253,6 +254,11 @@ class _PlayerActionsWidgetState extends State<PlayerActionsWidget>
                         widget.onProgramme!();
                       }
                     },
+                  ),
+                  const SizedBox(width: 8),
+                  XIconButton(
+                    icon: Icons.help_outline,
+                    onPressed: () => OperationHintDialog.show(context),
                   ),
                   const SizedBox(width: 8),
                   XIconButton(

--- a/lib/providers/media_provider.dart
+++ b/lib/providers/media_provider.dart
@@ -33,6 +33,9 @@ class MediaProvider with ChangeNotifier {
   // 首页频道项显示大小档位(0 最大 .. 4 最小,2=默认)
   int _gridSizeLevel = 2;
 
+  // 测速后是否隐藏「无法播放」的频道(可恢复,持久化)
+  bool _hideUnplayable = false;
+
   // 频道测试相关
   Map<String, ChannelTestResult> _channelTestResults = {};
   bool _isTesting = false;
@@ -64,8 +67,45 @@ class MediaProvider with ChangeNotifier {
   String? get selectedGroup => _selectedGroup;
 
   /// 应用「搜索 + 分组」过滤后的频道(供网格展示)。
-  List<Channel> get filteredChannels =>
-      filterChannels(channels, query: _searchQuery, group: _selectedGroup);
+  /// 若已测速:可选隐藏「无法播放」的频道,并把「可播放」排到前面。
+  List<Channel> get filteredChannels {
+    var list =
+        filterChannels(channels, query: _searchQuery, group: _selectedGroup);
+    if (_channelTestResults.isEmpty) return list;
+
+    if (_hideUnplayable) {
+      list = list.where((c) {
+        final r = _channelTestResults[c.id];
+        // 仅隐藏明确失败/超时的;未测与成功的保留
+        return r == null ||
+            (r.status != TestStatus.failed && r.status != TestStatus.timeout);
+      }).toList();
+    }
+
+    // 可播放优先:成功(按延迟升序) → 未测 → 失败/超时
+    int rank(Channel c) {
+      final r = _channelTestResults[c.id];
+      if (r == null) return 1;
+      if (r.status == TestStatus.success) return 0;
+      return 2;
+    }
+
+    final sorted = [...list];
+    sorted.sort((a, b) {
+      final ra = rank(a), rb = rank(b);
+      if (ra != rb) return ra - rb;
+      final la = _channelTestResults[a.id]?.latency ?? 1 << 30;
+      final lb = _channelTestResults[b.id]?.latency ?? 1 << 30;
+      return la.compareTo(lb);
+    });
+    return sorted;
+  }
+
+  /// 是否已有测速结果(决定「隐藏无法播放」入口是否出现)。
+  bool get hasTestResults => _channelTestResults.isNotEmpty;
+
+  /// 是否隐藏无法播放的频道。
+  bool get hideUnplayable => _hideUnplayable;
 
   /// 当前频道里去重的分组(供筛选 chips)。
   List<String> get availableGroups => distinctGroups(channels);
@@ -173,6 +213,21 @@ class MediaProvider with ChangeNotifier {
     await prefs.setInt('grid_size_level', _gridSizeLevel);
   }
 
+  /// 读取持久化的「隐藏无法播放」开关。
+  Future<void> loadHideUnplayable() async {
+    final prefs = await SharedPreferences.getInstance();
+    _hideUnplayable = prefs.getBool('hide_unplayable') ?? false;
+    notifyListeners();
+  }
+
+  /// 设置并持久化「隐藏无法播放」开关。
+  Future<void> setHideUnplayable(bool value) async {
+    _hideUnplayable = value;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('hide_unplayable', value);
+  }
+
   void _resetFilters() {
     _searchQuery = '';
     _selectedGroup = null;
@@ -198,6 +253,9 @@ class MediaProvider with ChangeNotifier {
 
       // 加载显示大小偏好
       await loadGridSizeLevel();
+
+      // 加载「隐藏无法播放」偏好
+      await loadHideUnplayable();
 
       // 首启无任何源时,自动添加并选中默认预置源(iptv-org 中国;运行时拉取)
       await _maybeSeedDefaultPreset();

--- a/lib/providers/media_provider.dart
+++ b/lib/providers/media_provider.dart
@@ -36,6 +36,9 @@ class MediaProvider with ChangeNotifier {
   // 测速后是否隐藏「无法播放」的频道(可恢复,持久化)
   bool _hideUnplayable = false;
 
+  // 启动时是否自动联网更新频道/节目单(后台静默,不阻塞进入;持久化,默认开)
+  bool _autoRefreshOnLaunch = true;
+
   // 频道测试相关
   Map<String, ChannelTestResult> _channelTestResults = {};
   bool _isTesting = false;
@@ -106,6 +109,9 @@ class MediaProvider with ChangeNotifier {
 
   /// 是否隐藏无法播放的频道。
   bool get hideUnplayable => _hideUnplayable;
+
+  /// 启动时是否自动更新(后台静默刷新)。
+  bool get autoRefreshOnLaunch => _autoRefreshOnLaunch;
 
   /// 当前频道里去重的分组(供筛选 chips)。
   List<String> get availableGroups => distinctGroups(channels);
@@ -228,6 +234,21 @@ class MediaProvider with ChangeNotifier {
     await prefs.setBool('hide_unplayable', value);
   }
 
+  /// 读取「启动时自动更新」开关(默认开)。
+  Future<void> loadAutoRefreshOnLaunch() async {
+    final prefs = await SharedPreferences.getInstance();
+    _autoRefreshOnLaunch = prefs.getBool('auto_refresh_on_launch') ?? true;
+    notifyListeners();
+  }
+
+  /// 设置并持久化「启动时自动更新」开关。
+  Future<void> setAutoRefreshOnLaunch(bool value) async {
+    _autoRefreshOnLaunch = value;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('auto_refresh_on_launch', value);
+  }
+
   void _resetFilters() {
     _searchQuery = '';
     _selectedGroup = null;
@@ -260,21 +281,36 @@ class MediaProvider with ChangeNotifier {
       // 首启无任何源时,自动添加并选中默认预置源(iptv-org 中国;运行时拉取)
       await _maybeSeedDefaultPreset();
 
+      // 加载「启动时自动更新」偏好
+      await loadAutoRefreshOnLaunch();
+
       // 加载收藏频道
       await fetchFavoriteChannels();
 
-      // 加载上次选择的播放列表
+      // 加载上次选择的播放列表(频道走缓存优先,启动快;不在此处阻塞联网)
       await loadLastSelectedPlaylistId();
-
-      // 加载节目单
-      await refreshProgrammes();
-
     } catch (e) {
       print('[MediaProvider] 初始化失败: $e');
     } finally {
       _isInitializing = false;
       notifyListeners();
     }
+
+    // 进入首页后,若开启「启动时自动更新」,后台静默刷新频道 + 节目单,
+    // 不阻塞进入(修复每次启动都卡在联网更新导致很慢的问题)。
+    if (_autoRefreshOnLaunch) {
+      _refreshOnLaunchInBackground();
+    }
+  }
+
+  /// 启动后台静默刷新:失败不打扰(已有本地缓存兜底)。
+  Future<void> _refreshOnLaunchInBackground() async {
+    try {
+      await fetchChannels(forceRefresh: true, silent: true);
+    } catch (_) {}
+    try {
+      await refreshProgrammes();
+    } catch (_) {}
   }
 
   /// 首启无源时,自动添加并选中默认预置源(运行时拉取,不打包快照)。
@@ -380,32 +416,54 @@ class MediaProvider with ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> fetchChannels() async {
+  /// 加载当前播放列表的频道。
+  /// - 默认「缓存优先」:有本地缓存就直接用,不联网(启动/切换都很快);
+  /// - [forceRefresh]=true 才联网重拉并写回缓存(手动刷新 / 后台自动更新);
+  /// - [silent]=true 时联网失败不弹 toast(后台刷新用)。
+  Future<void> fetchChannels(
+      {bool forceRefresh = false, bool silent = false}) async {
     if (_currentPlaylistId == -1) {
       _channels = _favoriteChannels; // 使用收藏频道
-    } else {
-      final playlist =
-          await _playlistRepository.getPlaylistById(_currentPlaylistId);
-      if (playlist == null) {
-        _channels = [];
-      } else {
-        try {
-          final updatedChannels = await _playlistRepository
-              .updatePlaylistWithM3uById(_currentPlaylistId, playlist.url);
-          _channels = updatedChannels.toChannels();
-        } catch (error) {
-          showToast(error.toString()); // 使用正确的导入
-          // Fallback: 从文件存储读取已保存的channels
-          final channelsJson = await _playlistRepository.getPlaylistChannels(_currentPlaylistId);
-          _channels = parseChannels(channelsJson ?? '');
-        }
+      notifyListeners();
+      return;
+    }
+
+    final playlist =
+        await _playlistRepository.getPlaylistById(_currentPlaylistId);
+    if (playlist == null) {
+      _channels = [];
+      notifyListeners();
+      return;
+    }
+
+    // 缓存优先:避免每次启动/切换都联网重拉(慢)
+    if (!forceRefresh) {
+      final cached =
+          await _playlistRepository.getPlaylistChannels(_currentPlaylistId);
+      if (cached != null && cached.isNotEmpty) {
+        _channels = parseChannels(cached);
+        notifyListeners();
+        return;
       }
+    }
+
+    // 强制刷新,或本地无缓存:联网拉取并写回缓存
+    try {
+      final updatedChannels = await _playlistRepository
+          .updatePlaylistWithM3uById(_currentPlaylistId, playlist.url);
+      _channels = updatedChannels.toChannels();
+    } catch (error) {
+      if (!silent) showToast(error.toString());
+      // Fallback: 从文件存储读取已保存的channels
+      final channelsJson =
+          await _playlistRepository.getPlaylistChannels(_currentPlaylistId);
+      _channels = parseChannels(channelsJson ?? '');
     }
     notifyListeners();
   }
 
   Future<void> refreshChannels() async {
-    await fetchChannels();
+    await fetchChannels(forceRefresh: true);
   }
 
   Future<void> toggleFavorite(Channel channel) async {

--- a/lib/services/channel_test_service.dart
+++ b/lib/services/channel_test_service.dart
@@ -15,50 +15,75 @@ class ChannelTestService {
   /// 返回：延迟毫秒数，null 表示失败
   /// 抛出 TimeoutException 表示超时
   Future<int?> testLatency(String url) async {
+    final stopwatch = Stopwatch()..start();
+    await _probe(url, 0);
+    stopwatch.stop();
+    return stopwatch.elapsedMilliseconds;
+  }
+
+  /// 递归探测一个地址是否真的可播。
+  /// HLS(.m3u8)清单只证明「清单在」,不证明「能播」;因此向下找真正的
+  /// 媒体分片/子清单再探(depth 限制 master→media→segment)。
+  Future<void> _probe(String url, int depth) async {
     final uri = Uri.parse(url);
     final httpClient = HttpClient();
     httpClient.connectionTimeout = _testTimeout;
     httpClient.badCertificateCallback = (cert, host, port) => true;
 
-    final stopwatch = Stopwatch()..start();
-
+    Uri? nextHls;
     try {
-      // 使用 GET 请求实际读取流数据（而不是 HEAD）
       final request = await httpClient.getUrl(uri).timeout(_testTimeout);
       final response = await request.close().timeout(_testTimeout);
 
-      // 检查状态码
       if (response.statusCode < 200 || response.statusCode >= 400) {
-        httpClient.close();
         throw Exception('HTTP ${response.statusCode}');
       }
 
-      // 尝试读取前 1KB 数据，确保流真的可用
-      int bytesRead = 0;
-      await for (var chunk in response.timeout(_testTimeout)) {
-        bytesRead += chunk.length;
-        if (bytesRead >= 1024) break; // 读取到 1KB 就停止
+      final isHls = url.toLowerCase().contains('.m3u8');
+      if (isHls && depth < 2) {
+        // 读取清单文本(最多 64KB),找第一个子项(变体清单或分片)
+        final buf = StringBuffer();
+        await for (final chunk in response.timeout(_testTimeout)) {
+          buf.write(String.fromCharCodes(chunk));
+          if (buf.length > 65536) break;
+        }
+        final text = buf.toString();
+        if (text.contains('#EXTM3U')) {
+          nextHls = _firstHlsUri(text, uri);
+          if (nextHls == null) {
+            throw Exception('空清单'); // 清单里没有任何可播放分片
+          }
+        }
+        // 非标准清单但能读到内容 → 视为可用(nextHls 为 null,不再下钻)
+      } else {
+        // 直链媒体或已到分片层:确认能读到真实字节
+        int bytesRead = 0;
+        await for (final chunk in response.timeout(_testTimeout)) {
+          bytesRead += chunk.length;
+          if (bytesRead >= 1024) break;
+        }
+        if (bytesRead == 0) {
+          throw Exception('No data');
+        }
       }
-
-      stopwatch.stop();
-
-      // 检查是否真的读到了数据
-      if (bytesRead == 0) {
-        httpClient.close();
-        throw Exception('No data');
-      }
-
-      httpClient.close();
-
-      // 返回延时（毫秒）
-      return stopwatch.elapsedMilliseconds;
-    } on TimeoutException {
-      httpClient.close();
-      rethrow; // 超时异常向上抛
-    } catch (e) {
-      httpClient.close();
-      rethrow; // 其他异常向上抛
+    } finally {
+      httpClient.close(force: true);
     }
+
+    // 下钻探测分片/子清单(在外层连接已关闭后进行)
+    if (nextHls != null) {
+      await _probe(nextHls.toString(), depth + 1);
+    }
+  }
+
+  /// 从 m3u8 文本取第一个非注释 URL,解析为绝对地址(相对则相对清单地址)。
+  Uri? _firstHlsUri(String manifest, Uri base) {
+    for (final raw in manifest.split('\n')) {
+      final line = raw.trim();
+      if (line.isEmpty || line.startsWith('#')) continue;
+      return base.resolve(line);
+    }
+    return null;
   }
 
   /// 截取视频缩略图（已禁用 - IPTV直播流不支持）
@@ -69,9 +94,8 @@ class ChannelTestService {
     return null;
   }
 
-  /// 测试单个频道
+  /// 测试单个频道:逐个源探测(最多前 3 个),任一可播即判定成功。
   Future<ChannelTestResult> testChannel(Channel channel) async {
-    // 取第一个视频源进行测试
     if (channel.source.isEmpty) {
       return ChannelTestResult(
         status: TestStatus.failed,
@@ -79,33 +103,32 @@ class ChannelTestService {
       );
     }
 
-    final videoUrl = channel.source.first.link;
+    bool sawTimeout = false;
+    Object? lastError;
 
-    try {
-      // 测试延时
-      final latency = await testLatency(videoUrl);
-
-      return ChannelTestResult(
-        latency: latency,
-        status: TestStatus.success,
-      );
-    } on TimeoutException {
-      // 超时
-      return ChannelTestResult(
-        status: TestStatus.timeout,
-        errorMessage: '超时',
-      );
-    } catch (e) {
-      // 流错误或其他错误
-      String errorMsg = '流错误';
-      if (e.toString().contains('HTTP')) {
-        errorMsg = e.toString().replaceAll('Exception: ', '');
+    // 多源频道:任一源可用即整体可播;最多测前 3 个源以控制耗时
+    for (final src in channel.source.take(3)) {
+      try {
+        final latency = await testLatency(src.link);
+        return ChannelTestResult(
+          latency: latency,
+          status: TestStatus.success,
+        );
+      } on TimeoutException {
+        sawTimeout = true;
+      } catch (e) {
+        lastError = e;
       }
-      return ChannelTestResult(
-        status: TestStatus.failed,
-        errorMessage: errorMsg,
-      );
     }
+
+    if (sawTimeout && lastError == null) {
+      return ChannelTestResult(status: TestStatus.timeout, errorMessage: '超时');
+    }
+    String errorMsg = '流错误';
+    if (lastError != null && lastError.toString().contains('HTTP')) {
+      errorMsg = lastError.toString().replaceAll('Exception: ', '');
+    }
+    return ChannelTestResult(status: TestStatus.failed, errorMessage: errorMsg);
   }
 
   /// 取消测试

--- a/lib/services/update/update_proxy.dart
+++ b/lib/services/update/update_proxy.dart
@@ -8,18 +8,32 @@ class UpdateProxy {
 
   static const String prefKey = 'update_proxy';
 
+  /// 归一化用户输入为 `host:port`:去掉 http(s):// 等 scheme 前缀、首尾空白
+  /// 与末尾路径/斜杠。HttpClient.findProxy 的 `PROXY host:port` 指令不接受
+  /// scheme,因此带 `http://`/`https://` 必须先剥掉,否则代理不生效。
+  static String? normalize(String? raw) {
+    var v = (raw ?? '').trim();
+    if (v.isEmpty) return null;
+    // 去掉任意 scheme://(http://、https://、socks5:// 等)
+    v = v.replaceFirst(RegExp(r'^[a-zA-Z][a-zA-Z0-9+.\-]*://'), '');
+    // 只保留 host:port,丢弃后面的路径
+    final slash = v.indexOf('/');
+    if (slash >= 0) v = v.substring(0, slash);
+    v = v.trim();
+    return v.isEmpty ? null : v;
+  }
+
   /// 读取已保存的代理（`host:port`）；未设置返回 null。
   static Future<String?> get() async {
     final prefs = await SharedPreferences.getInstance();
-    final v = prefs.getString(prefKey)?.trim();
-    return (v == null || v.isEmpty) ? null : v;
+    return normalize(prefs.getString(prefKey));
   }
 
-  /// 保存代理；传空字符串/ null 则清除（恢复直连）。
+  /// 保存代理；传空字符串/ null 则清除（恢复直连）。带 http(s):// 也兼容。
   static Future<void> set(String? value) async {
     final prefs = await SharedPreferences.getInstance();
-    final v = (value ?? '').trim();
-    if (v.isEmpty) {
+    final v = normalize(value);
+    if (v == null) {
       await prefs.remove(prefKey);
     } else {
       await prefs.setString(prefKey, v);


### PR DESCRIPTION
本轮交互式优化与修复合集(自 2.0.4 起):退出二次确认、播放加载失败体验(失败页可重试、防黑屏)、播放操作引导、测速改准(逐源+HLS)、测速后隐藏死频道、搜索/分组/大小独立入口、首页项大小可调、侧边栏美化、启动缓存优先(秒进)+自动更新开关、修复缓存解析致首页空、无频道刷新按钮、更新代理兼容 http(s)://、README 徽章、GitHub Issue 模板(中英)、推荐源新增 Free-TV/vbskycn/YueChan/fanmingming/joevess。analyze 0 errors,test 7/7。