### PR TITLE
fix(ios): 补 NSPhotoLibraryUsageDescription(修 ITMS-90683)

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -30,6 +30,8 @@
 		</array>
 		<key>NSLocalNetworkUsageDescription</key>
 		<string>用于在同一网络内发现和连接 TV 设备以进行远程输入</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>用于从相册/文件中选择本地播放列表或媒体文件进行播放。Used to pick local playlist or media files to play.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
file_picker 引用相册 API,缺 purpose string → ITMS-90683 被拒。补上。本地网络 keys 已在;permission_handler 定位/wifi 仅 Android。