### PR TITLE
fix(macos): 补 LSApplicationCategoryType 修 ITMS-90242;上传失败不再误报绿色

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -488,7 +488,9 @@ jobs:
 
       - name: Upload to App Store Connect
         if: env.MACOS_SIGNING_ENABLED == 'true'
-        continue-on-error: true
+        # 不要 continue-on-error:上传失败必须让本 job 变红(此 job 不在 release 的 needs 里,
+        # 所以不会阻塞 GitHub Release 发布)。之前的 continue-on-error 会把失败步骤的 conclusion
+        # 标成 success,导致 90242 上传失败时整个 run 仍显示绿色。
         env:
           APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
@@ -507,7 +509,7 @@ jobs:
         run: security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true
 
   ios:
-    name: iOS (signed → TestFlight + unsigned)
+    name: iOS (build signed IPA + unsigned)
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -681,30 +683,13 @@ jobs:
           fi
           ls -la xplayer-${VERSION}-* || true
 
-      - name: Upload to TestFlight
+      - name: Upload signed IPA artifact (consumed by ios_appstore job)
         if: env.IOS_SIGNING_ENABLED == 'true'
-        continue-on-error: true
-        env:
-          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
-        run: |
-          VERSION="${{ steps.meta.outputs.tag_name }}"
-          IPA_FILE="xplayer-${VERSION}-signed.ipa"
-          if [ ! -f "$IPA_FILE" ]; then echo "IPA missing, skip"; exit 0; fi
-          if [ -n "${APPLE_API_KEY_CONTENT:-}" ] && [ -n "${APPLE_API_KEY_ID:-}" ] && [ -n "${APPLE_API_ISSUER_ID:-}" ]; then
-            echo "Uploading to TestFlight via App Store Connect API Key..."
-            mkdir -p ~/.appstoreconnect/private_keys
-            P8_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8"
-            printf '%s' "$APPLE_API_KEY_CONTENT" > "$P8_PATH"
-            chmod 600 "$P8_PATH"
-            xcrun altool --upload-app --type ios --file "$IPA_FILE" \
-              --apiKey "$APPLE_API_KEY_ID" --apiIssuer "$APPLE_API_ISSUER_ID" --verbose
-            rm -f "$P8_PATH"
-            echo "Uploaded to TestFlight"
-          else
-            echo "No App Store Connect API key secrets — skipped TestFlight upload"
-          fi
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-signed
+          path: xplayer-*-signed.ipa
+          if-no-files-found: error
 
       - name: Upload iOS artifacts
         uses: actions/upload-artifact@v4
@@ -713,6 +698,46 @@ jobs:
           path: |
             xplayer-*-iphoneos.app.zip
             xplayer-*-unsigned.ipa
+
+  # TestFlight 上传独立成 job:上传失败时整个 run 会变红(无 continue-on-error),
+  # 但它不在 release 的 needs 里,所以不会阻塞 GitHub Release 发布。复用 ios job 产出的签名 ipa。
+  ios_appstore:
+    name: iOS → TestFlight
+    needs: [ios]
+    runs-on: macos-latest
+    steps:
+      - name: Download signed IPA
+        # 无签名 secrets 时 ios job 不会产出 ios-signed,这里下载失败属正常;
+        # 真正的上传失败由下一步(无 continue-on-error)暴露成红色。
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: ios-signed
+          path: signed
+      - name: Upload to TestFlight
+        env:
+          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          IPA_FILE=$(ls signed/*.ipa 2>/dev/null | head -1 || true)
+          if [ -z "$IPA_FILE" ]; then
+            echo "No signed IPA artifact (iOS signing disabled) — nothing to upload"
+            exit 0
+          fi
+          if [ -z "${APPLE_API_KEY_CONTENT:-}" ] || [ -z "${APPLE_API_KEY_ID:-}" ] || [ -z "${APPLE_API_ISSUER_ID:-}" ]; then
+            echo "No App Store Connect API key secrets — skipped TestFlight upload"
+            exit 0
+          fi
+          echo "Uploading $IPA_FILE to TestFlight..."
+          mkdir -p ~/.appstoreconnect/private_keys
+          P8="$HOME/.appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8"
+          printf '%s' "$APPLE_API_KEY_CONTENT" > "$P8"; chmod 600 "$P8"
+          xcrun altool --upload-app --type ios --file "$IPA_FILE" \
+            --apiKey "$APPLE_API_KEY_ID" --apiIssuer "$APPLE_API_ISSUER_ID" --verbose
+          rm -f "$P8"
+          echo "Uploaded to TestFlight"
 
   linux:
     name: Linux (tar.gz)

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -20,6 +20,8 @@
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.entertainment</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSBonjourServices</key>


### PR DESCRIPTION
## 背景
- macOS 上传到 App Store Connect 报 **ITMS-90242**:`The Info.plist must contain a LSApplicationCategoryType key`,导致 ASC 里「macOS 没有可用构建版本」(构建从未真正上传)。
- 同时 workflow **显示绿色但上传其实失败了** —— 上传步骤的 `continue-on-error: true` 把失败步骤的 `conclusion` 标成 success,掩盖了 90242。

## 改动
1. **`macos/Runner/Info.plist`**:补 `LSApplicationCategoryType = public.app-category.entertainment`(对应商店「娱乐」分类)。已确认 Runner 主 target 用 `INFOPLIST_FILE = Runner/Info.plist`(`GENERATE_INFOPLIST_FILE` 仅在 RunnerTests),key 会进 `.app → .pkg`。
2. **CI 诚实化**(上传失败 → run 变红,但不阻塞 GitHub Release):
   - `macos_appstore` 的 Upload 步骤去掉 `continue-on-error`。
   - iOS TestFlight 上传从 `ios` job 拆出为独立 **`ios_appstore`** job(`needs: [ios]`,复用 `ios-signed` artifact),上传步骤无 `continue-on-error`。
   - 两个上传 job 都**不在** `release` 的 `needs` 里 → 失败不阻塞发布。
   - `ios` job 改名为 `iOS (build signed IPA + unsigned)`。
   - `release` 只按名字下载 5 个平台 artifact,不会把 `ios-signed`(App Store 专用包)带进公开 Release。

## 验证
- `ruby -ryaml` 解析通过。
- job 图:`ios_appstore needs [ios]`、`release needs [android, windows, macos, ios, linux]`(不含两个 appstore job)。

合并后打 `2.0.10` 触发,这次 macOS 应能真正上传到 ASC;若上传失败,run 会变红可见。