### PR TITLE
feat: SurfaceView(platformView) 渲染追平电视画质 + 操作栏自动关闭修复 (2.1.1)

### DIFF
--- a/lib/presentation/screens/player.dart
+++ b/lib/presentation/screens/player.dart
@@ -153,7 +153,10 @@ class _PlayerScreenState extends State<PlayerScreen>
 
     try {
       _controller = VideoPlayerController.networkUrl(Uri.parse(_sourceLink),
-          videoPlayerOptions: VideoPlayerOptions(mixWithOthers: true));
+          videoPlayerOptions: VideoPlayerOptions(mixWithOthers: true),
+          // 用 SurfaceView 渲染(而非 Flutter 纹理):视频直送显示层,吃到设备/电视的
+          // 硬件视频引擎(放大+锐化)。这是和 TVMate 在电视上清晰度差距的关键。
+          viewType: VideoViewType.platformView);
 
       _controller.addListener(_listenToVideoController);
 

--- a/lib/presentation/screens/player.dart
+++ b/lib/presentation/screens/player.dart
@@ -291,6 +291,17 @@ class _PlayerScreenState extends State<PlayerScreen>
     }
   }
 
+  /// (重新)开始 5 秒自动收起操作栏的倒计时;有交互时调用即可重置。
+  /// 触发时直接 pop 掉操作栏那个 showGeneralDialog 顶层路由。
+  void _startAutoCloseTimer() {
+    cancelAutoCloseTimer();
+    autoCloseTimer = Timer(const Duration(seconds: 5), () {
+      if (mounted && _controlsVisible) {
+        Navigator.of(context).pop();
+      }
+    });
+  }
+
   void _showChannelSelectWidget(BuildContext context) {
     final mediaProvider = Provider.of<MediaProvider>(context, listen: false);
     final channels = mediaProvider.channels;
@@ -344,12 +355,8 @@ class _PlayerScreenState extends State<PlayerScreen>
   }
 
   void _showBottomControls() {
-    cancelAutoCloseTimer();
-
-    autoCloseTimer = Timer(const Duration(seconds: 5), () {
-      // _toggleControlsVisibility();
-      // Logger.debug(AppLocalizations.of(context)!.automaticClose);
-    });
+    // 开始 5 秒自动收起倒计时(之前这里定时器体被注释掉了 → 操作栏永不自动关闭)
+    _startAutoCloseTimer();
 
     Logger.debug('开启定时器');
 
@@ -381,7 +388,8 @@ class _PlayerScreenState extends State<PlayerScreen>
               }
             },
             onFocusChange: () {
-              cancelAutoCloseTimer();
+              // 有交互(如遥控器移动焦点)就重置倒计时,停手 5 秒后再自动收起
+              _startAutoCloseTimer();
             },
             onPlayPause: (isPlaying) {
               if (isPlaying) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1011,34 +1011,34 @@ packages:
     dependency: "direct main"
     description:
       name: video_player
-      sha256: "4a8c3492d734f7c39c2588a3206707a05ee80cef52e8c7f3b2078d430c84bc17"
+      sha256: "0d55b1f1a31e5ad4c4967bfaa8ade0240b07d20ee4af1dfef5f531056512961a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.2"
+    version: "2.10.0"
   video_player_android:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: video_player_android
-      sha256: "7018dbcb395e2bca0b9a898e73989e67c0c4a5db269528e1b036ca38bcca0d0b"
+      sha256: "28dcc4122079f40f93a0965b3679aff1a5f4251cf79611bd8011f937eb6b69de"
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.17"
+    version: "2.8.4"
   video_player_avfoundation:
     dependency: transitive
     description:
       name: video_player_avfoundation
-      sha256: "8a4e73a3faf2b13512978a43cf1cdda66feeeb900a0527f1fbfd7b19cf3458d3"
+      sha256: f9a780aac57802b2892f93787e5ea53b5f43cc57dc107bee9436458365be71cd
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.7"
+    version: "2.8.4"
   video_player_platform_interface:
     dependency: transitive
     description:
       name: video_player_platform_interface
-      sha256: "229d7642ccd9f3dc4aba169609dd6b5f3f443bb4cc15b82f7785fcada5af9bbb"
+      sha256: cf2a1d29a284db648fd66cbd18aacc157f9862d77d2cc790f6f9678a46c1db5a
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.3"
+    version: "6.4.0"
   video_player_web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,9 @@ dependencies:
   # 桌面端(Windows/Linux)用 FFI 时需要它打包 sqlite3 原生库,否则开库失败
   sqlite3_flutter_libs: ^0.5.0
   url_launcher: ^6.3.1
-  video_player: ^2.9.2
+  # 2.10.0 是支持 VideoViewType.platformView(SurfaceView 渲染)又仍兼容 Dart 3.6/Flutter 3.27 的版本;
+  # 2.10.1+ 要 Dart 3.7/Flutter 3.29。锁死 2.10.0,避免被升上去。
+  video_player: 2.10.0
   video_player_win: ^3.1.1
   xml: ^6.5.0
   bonsoir: ^5.1.11
@@ -52,9 +54,6 @@ dev_dependencies:
 
   flutter_launcher_icons: "^0.13.1"
   flutter_lints: ^2.0.0
-
-dependency_overrides:
-    video_player_android: 2.7.17
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## 改动
- 播放器改用 `video_player 2.10.0` 的 **VideoViewType.platformView(SurfaceView)** 渲染:视频直送显示层,吃到设备/电视的硬件视频引擎(放大+锐化),用于追平 TVMate 在电视上的清晰度。依据:logcat 显示原来走 texture(`mIsSurfaceToDisplay 0`、VPP 关闭)。
- 升级 `video_player` 2.9.2 → 2.10.0(去掉 `video_player_android: 2.7.17` override;2.10.0 是兼容 Flutter 3.27 的最高版)。
- 修复:操作栏 5 秒无操作**自动收起**(原定时器体被注释掉了),交互后重置倒计时。

## 验证清单
- [ ] 安卓电视上对比 TVMate,确认清晰度提升
- [ ] 全屏播放页:操作栏叠加/切台/旋转/返回无异常(platformView 已知坑)
- [ ] iOS/macOS/Windows 播放正常(platformView 仅安卓启用前提下)

⚠️ 注:platformView 目前对全平台开启,未在 iOS/macOS 上验证;操作栏收起在 SurfaceView 上偏僵硬(已知,本次未改)。