### PR TITLE
feat(diag): 诊断日志中心(读 logcat + 屏显/过滤 + 局域网 HTTP 导出)

### DIFF
--- a/android/app/src/main/kotlin/com/tntlikely/xplayer/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/tntlikely/xplayer/MainActivity.kt
@@ -1,6 +1,44 @@
 package com.tntlikely.xplayer
 
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+import java.io.BufferedReader
+import java.io.InputStreamReader
 
-class MainActivity: FlutterActivity() {
+class MainActivity : FlutterActivity() {
+    private val diagChannel = "diag/logcat"
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, diagChannel)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "getLogcat" -> {
+                        try {
+                            result.success(readLogcat())
+                        } catch (e: Exception) {
+                            result.error("LOGCAT_ERR", e.message, null)
+                        }
+                    }
+                    else -> result.notImplemented()
+                }
+            }
+    }
+
+    // 读取本应用最近的 logcat(-d:dump 后退出;-t:最后 N 行)。
+    // 普通应用经 exec 调 logcat 只能拿到自身 uid 的日志,正好含我们 pid 下的 MediaCodec 解码器行。
+    private fun readLogcat(): String {
+        val process = Runtime.getRuntime()
+            .exec(arrayOf("logcat", "-d", "-v", "time", "-t", "3000"))
+        val reader = BufferedReader(InputStreamReader(process.inputStream))
+        val sb = StringBuilder()
+        var line: String? = reader.readLine()
+        while (line != null) {
+            sb.append(line).append('\n')
+            line = reader.readLine()
+        }
+        reader.close()
+        return sb.toString()
+    }
 }

--- a/lib/presentation/screens/diag_log_screen.dart
+++ b/lib/presentation/screens/diag_log_screen.dart
@@ -1,0 +1,160 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// 诊断日志中心:
+/// - 原生 `diag/logcat` 通道读取本应用 logcat(含 MediaCodec 解码器行等)。
+/// - 屏上显示 + 关键字过滤 + 复制。
+/// - 起一个局域网 HTTP 服务,给出 `http://<本机IP>:8099/`,同 WiFi 的电脑可 curl/浏览器取全文
+///   —— 用于电视等无法连 adb 的设备把日志导出。
+class DiagLogScreen extends StatefulWidget {
+  const DiagLogScreen({super.key});
+
+  @override
+  State<DiagLogScreen> createState() => _DiagLogScreenState();
+}
+
+class _DiagLogScreenState extends State<DiagLogScreen> {
+  static const MethodChannel _channel = MethodChannel('diag/logcat');
+  static const int _port = 8099;
+
+  String _logs = '';
+  String _filter = '';
+  HttpServer? _server;
+  String _exportInfo = '局域网导出:启动中…';
+
+  @override
+  void initState() {
+    super.initState();
+    _refresh();
+    _startServer();
+  }
+
+  Future<String> _fetchLogcat() async {
+    try {
+      return await _channel.invokeMethod<String>('getLogcat') ?? '';
+    } on PlatformException catch (e) {
+      return '读取 logcat 失败:${e.message}\n(此设备/系统可能限制读取自身日志;仅 Android 支持)';
+    } on MissingPluginException {
+      return '当前平台不支持 logcat(仅 Android)。';
+    }
+  }
+
+  Future<void> _refresh() async {
+    final s = await _fetchLogcat();
+    if (mounted) setState(() => _logs = s);
+  }
+
+  Future<void> _startServer() async {
+    try {
+      _server = await HttpServer.bind(InternetAddress.anyIPv4, _port, shared: true);
+      _server!.listen((HttpRequest req) async {
+        final body = await _fetchLogcat();
+        req.response
+          ..headers.contentType = ContentType.text
+          ..write(body);
+        await req.response.close();
+      });
+      final ip = await _lanIp();
+      if (mounted) {
+        setState(() => _exportInfo = ip != null
+            ? '局域网导出(同一 WiFi 下电脑浏览器/curl 打开):\nhttp://$ip:$_port/'
+            : '已启动 $_port 端口,但未取到局域网 IP');
+      }
+    } catch (e) {
+      if (mounted) setState(() => _exportInfo = '启动局域网服务失败:$e');
+    }
+  }
+
+  Future<String?> _lanIp() async {
+    try {
+      final ifaces = await NetworkInterface.list(
+          type: InternetAddressType.IPv4, includeLoopback: false);
+      for (final iface in ifaces) {
+        for (final addr in iface.addresses) {
+          if (!addr.isLoopback) return addr.address;
+        }
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  @override
+  void dispose() {
+    _server?.close(force: true);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final lines = _logs
+        .split('\n')
+        .where((l) =>
+            _filter.isEmpty || l.toLowerCase().contains(_filter.toLowerCase()))
+        .toList();
+    return Scaffold(
+      backgroundColor: const Color.fromARGB(255, 18, 18, 18),
+      appBar: AppBar(
+        title: const Text('诊断日志', style: TextStyle(color: Colors.white)),
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        iconTheme: const IconThemeData(color: Colors.white),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.copy, color: Colors.white),
+            tooltip: '复制全部',
+            onPressed: () => Clipboard.setData(ClipboardData(text: _logs)),
+          ),
+          IconButton(
+            icon: const Icon(Icons.refresh, color: Colors.white),
+            tooltip: '刷新',
+            onPressed: _refresh,
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(12),
+            color: Colors.white10,
+            child: SelectableText(
+              _exportInfo,
+              style: const TextStyle(color: Colors.greenAccent, fontSize: 13),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            child: TextField(
+              style: const TextStyle(color: Colors.white, fontSize: 13),
+              decoration: const InputDecoration(
+                hintText: '过滤(如 decoder / c2. / error)',
+                hintStyle: TextStyle(color: Colors.white38),
+                isDense: true,
+                prefixIcon: Icon(Icons.search, color: Colors.white38, size: 18),
+              ),
+              onChanged: (v) => setState(() => _filter = v),
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: lines.length,
+              itemBuilder: (_, i) => Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 1),
+                child: SelectableText(
+                  lines[i],
+                  style: const TextStyle(
+                      color: Colors.white70,
+                      fontSize: 11,
+                      fontFamily: 'monospace'),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/home.dart
+++ b/lib/presentation/screens/home.dart
@@ -5,6 +5,7 @@ import 'package:xplayer/data/models/playlist_model.dart';
 // 导入 FavoritesRepository
 import 'package:xplayer/presentation/screens/playlist.dart';
 import 'package:xplayer/presentation/screens/epg_screen.dart';
+import 'package:xplayer/presentation/screens/diag_log_screen.dart';
 import 'package:xplayer/services/update_service.dart';
 import 'package:xplayer/shared/components/x_base_button.dart';
 import 'package:xplayer/presentation/widgets/bg_wrapper.dart';
@@ -527,6 +528,22 @@ class _HomeScreenState extends State<HomeScreen> {
                   onPressed: () {
                     Navigator.of(context).pop();
                     _showSizeDialog(context);
+                  },
+                ),
+                XBaseButton(
+                  child: animeContainer(
+                    ListTile(
+                      leading:
+                          const Icon(Icons.bug_report, color: Colors.white),
+                      title: const Text('诊断日志',
+                          style: TextStyle(color: Colors.white)),
+                    ),
+                  ),
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const DiagLogScreen()),
+                    );
                   },
                 ),
                 XBaseButton(


### PR DESCRIPTION
无 adb 设备(电视)排查用:抽屉「诊断日志」→ 原生读本应用 logcat + 屏上显示/过滤 + 起局域网 HTTP 服务给出 `http://<本机IP>:8099/`,同 WiFi 电脑 curl 取全文。用于查电视实际解码器(c2.qti/mtk/amlogic=硬解 vs c2.android=软解)。