### PR TITLE
fix(mini/tv): TV 小窗返回键回到在播频道

### DIFF
--- a/lib/presentation/screens/home.dart
+++ b/lib/presentation/screens/home.dart
@@ -36,6 +36,8 @@ import 'package:xplayer/localization/app_localizations.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:xplayer/providers/remote_provider.dart';
 import 'package:xplayer/providers/global_provider.dart';
+import 'package:xplayer/providers/mini_player_controller.dart';
+import 'package:xplayer/presentation/screens/player.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -278,6 +280,22 @@ class _HomeScreenState extends State<HomeScreen> {
         if (scaffold != null && scaffold.isDrawerOpen) {
           scaffold.closeDrawer();
           return;
+        }
+        // TV:遥控器够不到悬浮小窗(浮层在路由焦点域之外),用返回键回到在播频道。
+        // 手机靠点击小窗,这里不拦截(仍走退出确认)。
+        final isTv = Provider.of<GlobalProvider>(context, listen: false).isTV;
+        final mini = Provider.of<MiniPlayerController>(context, listen: false);
+        if (isTv && mini.hasMini) {
+          final ch = mini.channel;
+          final favs = mini.favorites;
+          if (ch != null) {
+            mini.take(); // 切回全屏(浮层隐藏),复用在播 backend
+            Navigator.of(context).push(MaterialPageRoute(
+              builder: (_) =>
+                  PlayerScreen(channel: ch, favoriteChannels: favs),
+            ));
+            return;
+          }
         }
         if (await _confirmExit(context)) {
           await SystemNavigator.pop();

--- a/lib/presentation/widgets/mini_player_overlay.dart
+++ b/lib/presentation/widgets/mini_player_overlay.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:xplayer/providers/mini_player_controller.dart';
+import 'package:xplayer/providers/global_provider.dart';
 import 'package:xplayer/presentation/screens/player.dart';
 import 'package:xplayer/shared/navigation.dart';
 
@@ -15,6 +16,7 @@ class MiniPlayerOverlay extends StatelessWidget {
         if (!c.hasMini) return const SizedBox.shrink();
         final media = MediaQuery.of(context);
         final card = miniCardRect(media.size, media.padding);
+        final isTv = Provider.of<GlobalProvider>(context, listen: false).isTV;
         void expand() {
           final ch = c.channel;
           if (ch == null) return;
@@ -49,21 +51,31 @@ class MiniPlayerOverlay extends StatelessWidget {
                         child: GestureDetector(
                           behavior: HitTestBehavior.opaque,
                           onTap: expand,
-                          child: const Align(
-                            alignment: Alignment.centerLeft,
-                            child: Icon(Icons.open_in_full,
-                                color: Colors.white70, size: 14),
+                          child: isTv
+                              // TV 遥控器够不到浮层,提示用返回键回到在播频道
+                              ? const Align(
+                                  alignment: Alignment.centerLeft,
+                                  child: Text('按 返回键 继续观看',
+                                      style: TextStyle(
+                                          color: Colors.white70, fontSize: 11)),
+                                )
+                              : const Align(
+                                  alignment: Alignment.centerLeft,
+                                  child: Icon(Icons.open_in_full,
+                                      color: Colors.white70, size: 14),
+                                ),
+                        ),
+                      ),
+                      // TV 上 X 同样够不到(用返回键展开、换台自动关),手机保留点击关闭
+                      if (!isTv)
+                        InkWell(
+                          onTap: () => c.close(),
+                          child: const Padding(
+                            padding: EdgeInsets.symmetric(horizontal: 6),
+                            child: Icon(Icons.close,
+                                color: Colors.white, size: 18),
                           ),
                         ),
-                      ),
-                      InkWell(
-                        onTap: () => c.close(),
-                        child: const Padding(
-                          padding: EdgeInsets.symmetric(horizontal: 6),
-                          child: Icon(Icons.close,
-                              color: Colors.white, size: 18),
-                        ),
-                      ),
                     ],
                   ),
                 ),


### PR DESCRIPTION
## 背景
TV 上遥控器够不到首页悬浮小窗(浮层在 MaterialApp.builder,处于路由焦点域之外,方向键无法 traverse 过去)。

## 改动
- 首页有小窗时,**返回键直接回到在播频道**(`take()` 切回全屏复用 backend),随时可用、不依赖焦点。仅 TV 生效;手机仍用点击小窗。
- 小窗顶部在 TV 上显示提示「按 返回键 继续观看」;关闭按钮仅手机保留。

## 验证
- 真机:首页有小窗时按返回键回到在播频道 ✅
- 全部单测通过

## 备注
不含 PiP/Manifest 改动(经验证 TV 卡顿与 PiP 标志无关)。