### PR TITLE
fix(appstore): 修复苹果审核被拒(2.4.5 自更新 / 2.1a 演示)

### DIFF
--- a/lib/presentation/screens/home.dart
+++ b/lib/presentation/screens/home.dart
@@ -830,8 +830,9 @@ class _HomeScreenState extends State<HomeScreen> {
                     );
                   },
                 ),
-                // iOS/iPadOS:App Store 不允许应用自更新,隐藏检查更新入口
-                if (!Platform.isIOS)
+                // 应用商店包(App Store / Mac App Store / Play)不允许应用自更新,
+                // 隐藏「检查更新」入口(Guideline 2.4.5)。侧载包(GitHub)保留。
+                if (!kStoreBuild)
                   XBaseButton(
                     child: animeContainer(
                       ListTile(


### PR DESCRIPTION
## 背景
Mac App Store 审核被拒(Submission e2a7c12a,版本 2.0.10):
- **2.4.5(vii)**: The app updates itself outside of the Mac App Store.
- **2.1(a)**: 审核员进 App 看不到内容(BYO 播放列表的纯播放器),需 demo / 演示。

## 改动(2.4.5)
`检查更新` 入口原来只用 `!Platform.isIOS` 隐藏 → **macOS App Store 包仍显示自更新入口**,被判定为应用在商店外自更新。
改为 **`!kStoreBuild`**:App Store / Mac App Store / Play 商店包隐藏「检查更新」;GitHub 侧载包保留自更新。
(CI 中 macOS App Store 与 iOS 均已 `--dart-define=STORE_BUILD=true`,故 kStoreBuild 生效。)

## 2.1(a)
不在 App 内置示例频道(避免夹带内容),改为在 **App Store Connect → App Review Information → Notes** 提供公开测试 M3U 的导入说明(见 PR 评论/发布说明)。

## 验证
- analyze 干净;商店包(STORE_BUILD=true)抽屉不再出现「检查更新」。