### PR TITLE
fix: 播放列表重名校验 + 操作栏溢出 + 启动节目单刷新

### DIFF
--- a/lib/localization/app_en.arb
+++ b/lib/localization/app_en.arb
@@ -146,6 +146,7 @@
   "recentlyPlayed": "Recently Played",
   "showRecentOnHome": "Show Recently Played on Home",
   "showFavoritesOnHome": "Show Favorites on Home",
+  "playlistNameExists": "A playlist with this name already exists",
   "miniPlayerOnExit": "Mini player on home",
   "miniPlayerOnExitHint": "Keep playing in a corner window when returning home",
   "pipOnLeave": "Picture-in-picture",

--- a/lib/localization/app_localizations.dart
+++ b/lib/localization/app_localizations.dart
@@ -974,6 +974,12 @@ abstract class AppLocalizations {
   /// **'Show Favorites on Home'**
   String get showFavoritesOnHome;
 
+  /// No description provided for @playlistNameExists.
+  ///
+  /// In en, this message translates to:
+  /// **'A playlist with this name already exists'**
+  String get playlistNameExists;
+
   /// No description provided for @miniPlayerOnExit.
   ///
   /// In en, this message translates to:

--- a/lib/localization/app_localizations_en.dart
+++ b/lib/localization/app_localizations_en.dart
@@ -477,6 +477,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get showFavoritesOnHome => 'Show Favorites on Home';
 
   @override
+  String get playlistNameExists => 'A playlist with this name already exists';
+
+  @override
   String get miniPlayerOnExit => 'Mini player on home';
 
   @override

--- a/lib/localization/app_localizations_zh.dart
+++ b/lib/localization/app_localizations_zh.dart
@@ -470,6 +470,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get showFavoritesOnHome => '首页收藏';
 
   @override
+  String get playlistNameExists => '已存在同名播放列表';
+
+  @override
   String get miniPlayerOnExit => '返回小窗续播';
 
   @override

--- a/lib/localization/app_zh.arb
+++ b/lib/localization/app_zh.arb
@@ -146,6 +146,7 @@
     "recentlyPlayed": "最近播放",
     "showRecentOnHome": "首页最近播放",
     "showFavoritesOnHome": "首页收藏",
+    "playlistNameExists": "已存在同名播放列表",
     "miniPlayerOnExit": "返回小窗续播",
     "miniPlayerOnExitHint": "从播放页返回首页时,在右下角小窗继续播放",
     "pipOnLeave": "回桌面画中画",

--- a/lib/presentation/widgets/player_actions_widget.dart
+++ b/lib/presentation/widgets/player_actions_widget.dart
@@ -360,15 +360,18 @@ class _PlayerActionsWidgetState extends State<PlayerActionsWidget>
                   Row(mainAxisSize: MainAxisSize.min, children: actionButtons),
                 ],
               )
-            // 窄屏:信息在上、按钮在下并左对齐
+            // 窄屏:信息在上、按钮在下;按钮可能多于一屏宽 → 横向可滚动,避免溢出
             : Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   infoRow,
                   const SizedBox(height: 8),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    children: actionButtons,
+                  SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: actionButtons,
+                    ),
                   ),
                   const SizedBox(height: 8),
                 ],

--- a/lib/presentation/widgets/playlist_dialog.dart
+++ b/lib/presentation/widgets/playlist_dialog.dart
@@ -139,6 +139,17 @@ class _PlaylistDialogState extends State<PlaylistDialog> {
       return;
     }
 
+    // 重名校验:不允许与已有播放列表同名(编辑时排除自己)
+    final existing = await _repository.getAllPlaylists();
+    final dup = existing.any((p) =>
+        p.name.trim() == newPlaylist.name &&
+        p.id != widget.initialPlaylist?.id);
+    if (dup) {
+      if (!mounted) return;
+      showToast(AppLocalizations.of(context)!.playlistNameExists);
+      return;
+    }
+
     try {
       Playlist playlist;
       if (widget.isNew) {

--- a/lib/providers/media_provider.dart
+++ b/lib/providers/media_provider.dart
@@ -361,17 +361,18 @@ class MediaProvider with ChangeNotifier {
   }
 
   /// 启动后台静默刷新:按各自开关执行;失败不打扰(已有本地缓存兜底)。
+  /// 频道与节目单**并行**刷新——否则节目单会被("强制重下整个 m3u"的)频道刷新
+  /// 串行拖住甚至卡死,导致启动后迟迟没有节目单(用户得手动再刷一次)。
   Future<void> _refreshOnLaunchInBackground() async {
+    final tasks = <Future<void>>[];
     if (_autoRefreshChannels) {
-      try {
-        await fetchChannels(forceRefresh: true, silent: true);
-      } catch (_) {}
+      tasks.add(fetchChannels(forceRefresh: true, silent: true)
+          .catchError((_) {}));
     }
     if (_autoRefreshProgrammes) {
-      try {
-        await refreshProgrammes();
-      } catch (_) {}
+      tasks.add(refreshProgrammes().catchError((_) {}));
     }
+    await Future.wait(tasks);
   }
 
   /// 首启无源时,自动添加并选中默认预置源(运行时拉取,不打包快照)。


### PR DESCRIPTION
三个小 bug:

1. **播放列表重名**:新建/编辑时校验,已存在同名(编辑排除自己)则报错不保存。
2. **手机操作栏溢出**:窄屏(手机竖屏)按钮过多时横向可滚动,消除 RenderFlex overflow。
3. **启动没有节目单**:节目单刷新原本串行排在「强制重下整个 m3u」的频道刷新之后,被拖住/卡死,导致进来没有 EPG、需手动再刷。改为**频道与节目单并行刷新**,节目单用已存 epgUrl 立即开拉。

验证:analyze 干净(仅历史遗留告警),41 测试通过。