### PR TITLE
feat: DLNA 局域网投屏 + TV GitHub 二维码弹窗

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import 'package:xplayer/providers/remote_provider.dart';
 import 'package:xplayer/presentation/screens/remote_input.dart';
 import 'package:xplayer/shared/navigation.dart';
 import 'package:xplayer/providers/mini_player_controller.dart';
+import 'package:xplayer/providers/cast_provider.dart';
 import 'package:xplayer/presentation/widgets/mini_player_overlay.dart';
 import 'package:xplayer/shared/theme/app_theme.dart';
 import 'package:xplayer/services/log_store.dart';
@@ -85,6 +86,7 @@ void main() {
       ChangeNotifierProvider(create: (_) => GlobalProvider()..loadDeviceInfo()),
       ChangeNotifierProvider(create: (_) => RemoteProvider()),
       ChangeNotifierProvider(create: (_) => MiniPlayerController()),
+      ChangeNotifierProvider(create: (_) => CastProvider()),
     ], child: const MyApp()));
     _winLog('runApp returned');
   }, (Object error, StackTrace stack) {

--- a/lib/presentation/screens/home.dart
+++ b/lib/presentation/screens/home.dart
@@ -34,6 +34,7 @@ import 'package:xplayer/providers/media_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:xplayer/localization/app_localizations.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:qr_flutter/qr_flutter.dart';
 import 'package:xplayer/providers/remote_provider.dart';
 import 'package:xplayer/providers/global_provider.dart';
 import 'package:xplayer/providers/mini_player_controller.dart';
@@ -926,23 +927,46 @@ class _HomeScreenState extends State<HomeScreen> {
                       showDialog(
                         context: context,
                         builder: (_) => AlertDialog(
-                          title: const Text('Github'),
+                          backgroundColor: AppTokens.surfacePanel,
+                          title: const Text('Github',
+                              style: TextStyle(color: AppTokens.textPrimary)),
                           content: Column(
                             mainAxisSize: MainAxisSize.min,
-                            crossAxisAlignment: CrossAxisAlignment.start,
+                            crossAxisAlignment: CrossAxisAlignment.center,
                             children: [
-                              Text(localizations.githubTvHint),
-                              const SizedBox(height: 8),
+                              Text(
+                                localizations.githubTvHint,
+                                style: const TextStyle(
+                                    color: AppTokens.textSecondary),
+                              ),
+                              const SizedBox(height: 16),
+                              // 二维码:手机扫码直达;白底保证暗色弹窗下可识别
+                              Container(
+                                padding: const EdgeInsets.all(12),
+                                decoration: BoxDecoration(
+                                  color: Colors.white,
+                                  borderRadius: BorderRadius.circular(8),
+                                ),
+                                child: QrImageView(
+                                  data: url,
+                                  version: QrVersions.auto,
+                                  size: 200,
+                                  backgroundColor: Colors.white,
+                                ),
+                              ),
+                              const SizedBox(height: 12),
                               const SelectableText(
                                 url,
-                                style: TextStyle(fontWeight: FontWeight.w600),
+                                style: TextStyle(
+                                    color: AppTokens.textPrimary,
+                                    fontWeight: FontWeight.w600),
                               ),
                             ],
                           ),
                           actions: [
-                            TextButton(
+                            XTextButton(
+                              text: localizations.cancel,
                               onPressed: () => Navigator.of(context).pop(),
-                              child: Text(localizations.cancel),
                             ),
                           ],
                         ),

--- a/lib/presentation/screens/player.dart
+++ b/lib/presentation/screens/player.dart
@@ -17,6 +17,7 @@ import 'package:xplayer/utils/logger_util.dart';
 import 'package:xplayer/utils/hls_probe.dart';
 import 'package:xplayer/services/sleep_timer.dart';
 import 'package:xplayer/providers/mini_player_controller.dart';
+import 'package:xplayer/presentation/widgets/cast_device_sheet.dart';
 import 'package:xplayer/utils/playlist_util.dart';
 import 'package:xplayer/utils/toast.dart';
 import 'package:xplayer/services/log_store.dart';
@@ -586,6 +587,8 @@ class _PlayerScreenState extends State<PlayerScreen>
                 Navigator.of(context).pop(); // 关闭操作栏
                 _showStreamInfoSheet(context);
               },
+              // 投屏(DLNA):仅非 TV 显示(TV 自己就是大屏)
+              onCast: _isTv ? null : () => _showCastSheet(context),
             ),
           ),
         );
@@ -724,6 +727,17 @@ class _PlayerScreenState extends State<PlayerScreen>
         _initializePlayer();
         if (mounted) Navigator.of(context).pop();
       },
+    );
+  }
+
+  /// 投屏面板:把当前播放地址投到局域网 DLNA 设备;投出成功暂停本地播放。
+  void _showCastSheet(BuildContext context) {
+    if (_controlsVisible) Navigator.of(context).pop(); // 先关操作栏
+    CastDeviceSheet.show(
+      context,
+      url: _playUrl,
+      title: _channel.name,
+      onCasted: () => _backend.pause(),
     );
   }
 

--- a/lib/presentation/widgets/cast_device_sheet.dart
+++ b/lib/presentation/widgets/cast_device_sheet.dart
@@ -1,0 +1,221 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:xplayer/providers/cast_provider.dart';
+import 'package:xplayer/shared/theme/app_tokens.dart';
+
+/// 投屏设备选择面板(DLNA)。打开即扫描;选中设备把 [url] 投出去。
+/// 已在投屏中则显示当前设备与控制(暂停/播放/停止)。
+class CastDeviceSheet extends StatefulWidget {
+  final String url;
+  final String title;
+  final VoidCallback? onCasted; // 投出成功(供调用方暂停本地播放)
+
+  const CastDeviceSheet({
+    super.key,
+    required this.url,
+    required this.title,
+    this.onCasted,
+  });
+
+  static Future<void> show(BuildContext context,
+      {required String url,
+      required String title,
+      VoidCallback? onCasted}) {
+    return showModalBottomSheet(
+      context: context,
+      backgroundColor: AppTokens.surfacePanel,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (_) =>
+          CastDeviceSheet(url: url, title: title, onCasted: onCasted),
+    );
+  }
+
+  @override
+  State<CastDeviceSheet> createState() => _CastDeviceSheetState();
+}
+
+class _CastDeviceSheetState extends State<CastDeviceSheet> {
+  @override
+  void initState() {
+    super.initState();
+    // 打开即扫描一次
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<CastProvider>().refresh();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<CastProvider>(
+      builder: (context, cast, _) {
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    const Icon(Icons.cast, color: Colors.white),
+                    const SizedBox(width: 8),
+                    const Expanded(
+                      child: Text('投屏到电视',
+                          style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 16,
+                              fontWeight: FontWeight.bold)),
+                    ),
+                    if (cast.state == CastState.discovering)
+                      const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2))
+                    else
+                      IconButton(
+                        icon: const Icon(Icons.refresh, color: Colors.white70),
+                        onPressed: () => cast.refresh(),
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                if (cast.isCasting) _castingView(cast) else _deviceList(cast),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _castingView(CastProvider cast) {
+    final playing = cast.transport == 'PLAYING';
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('正在投到:${cast.current?.friendlyName ?? ''}',
+            style: const TextStyle(color: Colors.white70)),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            XActionChip(
+              icon: playing ? Icons.pause : Icons.play_arrow,
+              label: playing ? '暂停' : '播放',
+              onTap: () => playing ? cast.pause() : cast.play(),
+            ),
+            const SizedBox(width: 12),
+            XActionChip(
+              icon: Icons.stop,
+              label: '停止投屏',
+              onTap: () async {
+                await cast.stopCast();
+                if (mounted) Navigator.of(context).maybePop();
+              },
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _deviceList(CastProvider cast) {
+    if (cast.state == CastState.discovering && cast.devices.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 24),
+        child: Center(
+            child: Text('正在搜索设备…',
+                style: TextStyle(color: Colors.white54))),
+      );
+    }
+    if (cast.devices.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 20),
+        child: Column(
+          children: [
+            const Text('未发现可投设备',
+                style: TextStyle(color: Colors.white70)),
+            const SizedBox(height: 4),
+            const Text('请确认电视与手机在同一 Wi-Fi,且电视已开启投屏/DLNA',
+                textAlign: TextAlign.center,
+                style: TextStyle(color: Colors.white38, fontSize: 12)),
+            if (cast.error != null) ...[
+              const SizedBox(height: 6),
+              Text(cast.error!,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(color: Colors.orange, fontSize: 12)),
+            ],
+          ],
+        ),
+      );
+    }
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: 320),
+      child: ListView.builder(
+        shrinkWrap: true,
+        itemCount: cast.devices.length,
+        itemBuilder: (_, i) {
+          final d = cast.devices[i];
+          return ListTile(
+            leading: const Icon(Icons.tv, color: Colors.white70),
+            title: Text(d.friendlyName,
+                style: const TextStyle(color: Colors.white)),
+            subtitle: const Text('DLNA',
+                style: TextStyle(color: Colors.white38, fontSize: 11)),
+            onTap: () async {
+              final ok = await cast.castTo(d,
+                  url: widget.url, title: widget.title);
+              if (!mounted) return;
+              if (ok) {
+                widget.onCasted?.call();
+                ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                    content: Text('已投到 ${d.friendlyName}')));
+              } else {
+                ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                    content:
+                        Text(cast.error ?? '投屏失败,该设备可能不支持此源')));
+              }
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// 简易动作按钮(图标 + 文字)。
+class XActionChip extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+  const XActionChip(
+      {super.key,
+      required this.icon,
+      required this.label,
+      required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+        decoration: BoxDecoration(
+          color: Colors.white10,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, color: Colors.white, size: 18),
+            const SizedBox(width: 6),
+            Text(label, style: const TextStyle(color: Colors.white)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/cast_device_sheet.dart
+++ b/lib/presentation/widgets/cast_device_sheet.dart
@@ -60,7 +60,7 @@ class _CastDeviceSheetState extends State<CastDeviceSheet> {
               children: [
                 Row(
                   children: [
-                    const Icon(Icons.cast, color: Colors.white),
+                    const Icon(Icons.live_tv, color: Colors.white),
                     const SizedBox(width: 8),
                     const Expanded(
                       child: Text('投屏到电视',

--- a/lib/presentation/widgets/player_actions_widget.dart
+++ b/lib/presentation/widgets/player_actions_widget.dart
@@ -314,7 +314,7 @@ class _PlayerActionsWidgetState extends State<PlayerActionsWidget>
       // 投屏(DLNA):始终显示
       if (widget.onCast != null) ...[
         XIconButton(
-          icon: Icons.cast,
+          icon: Icons.live_tv,
           onPressed: () => widget.onCast!(),
         ),
         const SizedBox(width: 8),

--- a/lib/presentation/widgets/player_actions_widget.dart
+++ b/lib/presentation/widgets/player_actions_widget.dart
@@ -43,6 +43,7 @@ class PlayerActionsWidget extends StatefulWidget {
   /// 是否有多音轨(决定音轨按钮是否显示)
   final bool hasAudioTracks;
   final VoidCallback? showAudioTrackSelect;
+  final VoidCallback? onCast;
 
   const PlayerActionsWidget(
       {Key? key,
@@ -61,7 +62,8 @@ class PlayerActionsWidget extends StatefulWidget {
       this.showQualitySelect,
       this.showSleepTimer,
       this.hasAudioTracks = false,
-      this.showAudioTrackSelect})
+      this.showAudioTrackSelect,
+      this.onCast})
       : super(key: key);
 
   @override
@@ -306,6 +308,14 @@ class _PlayerActionsWidgetState extends State<PlayerActionsWidget>
               widget.showAudioTrackSelect!();
             }
           },
+        ),
+        const SizedBox(width: 8),
+      ],
+      // 投屏(DLNA):始终显示
+      if (widget.onCast != null) ...[
+        XIconButton(
+          icon: Icons.cast,
+          onPressed: () => widget.onCast!(),
         ),
         const SizedBox(width: 8),
       ],

--- a/lib/providers/cast_provider.dart
+++ b/lib/providers/cast_provider.dart
@@ -1,0 +1,131 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:xplayer/services/cast/dlna_device.dart';
+import 'package:xplayer/services/cast/dlna_discovery.dart';
+import 'package:xplayer/services/cast/dlna_controller.dart';
+
+enum CastState { idle, discovering, connecting, casting, error }
+
+/// 投屏状态机:发现 DLNA 设备、投出、远端控制与状态轮询。
+class CastProvider with ChangeNotifier {
+  final DlnaDiscovery _discovery = DlnaDiscovery();
+
+  CastState _state = CastState.idle;
+  CastState get state => _state;
+
+  List<DlnaDevice> _devices = [];
+  List<DlnaDevice> get devices => List.unmodifiable(_devices);
+
+  DlnaDevice? _current;
+  DlnaDevice? get current => _current;
+  bool get isCasting => _current != null;
+
+  String? _transport; // PLAYING / PAUSED_PLAYBACK / STOPPED ...
+  String? get transport => _transport;
+  Duration _position = Duration.zero;
+  Duration get position => _position;
+
+  String? _error;
+  String? get error => _error;
+
+  DlnaController? _ctrl;
+  Timer? _poll;
+
+  /// 扫描局域网 DLNA 设备。
+  Future<void> refresh() async {
+    if (_state == CastState.discovering) return;
+    _state = CastState.discovering;
+    _error = null;
+    notifyListeners();
+    try {
+      _devices = await _discovery.search();
+    } catch (e) {
+      _error = '$e';
+    }
+    _state = isCasting ? CastState.casting : CastState.idle;
+    notifyListeners();
+  }
+
+  /// 把某地址投到设备。成功开始状态轮询。
+  Future<bool> castTo(DlnaDevice device,
+      {required String url, required String title}) async {
+    _state = CastState.connecting;
+    _error = null;
+    notifyListeners();
+
+    final ctrl = DlnaController(device);
+    final ok = await ctrl.setUriAndPlay(url, title: title);
+    if (!ok) {
+      _state = CastState.error;
+      _error = '该设备未能播放此源(可能不支持该格式/直播)';
+      notifyListeners();
+      return false;
+    }
+    _ctrl = ctrl;
+    _current = device;
+    _transport = 'PLAYING';
+    _position = Duration.zero;
+    _state = CastState.casting;
+    notifyListeners();
+    _startPolling();
+    return true;
+  }
+
+  Future<void> pause() async {
+    await _ctrl?.pause();
+    _transport = 'PAUSED_PLAYBACK';
+    notifyListeners();
+  }
+
+  Future<void> play() async {
+    await _ctrl?.play();
+    _transport = 'PLAYING';
+    notifyListeners();
+  }
+
+  /// 停止投屏(通知设备 Stop 并清理本地状态)。返回投屏时的最后进度,供手机续播。
+  Future<Duration> stopCast() async {
+    final pos = _position;
+    _poll?.cancel();
+    _poll = null;
+    await _ctrl?.stop();
+    _ctrl = null;
+    _current = null;
+    _transport = null;
+    _position = Duration.zero;
+    _state = CastState.idle;
+    notifyListeners();
+    return pos;
+  }
+
+  void _startPolling() {
+    _poll?.cancel();
+    _poll = Timer.periodic(const Duration(seconds: 2), (_) async {
+      final c = _ctrl;
+      if (c == null) return;
+      final st = await c.transportState();
+      final pos = await c.position();
+      if (_ctrl == null) return; // 轮询期间已停止
+      if (st != null) _transport = st;
+      if (pos != null) _position = pos;
+      // 远端自然结束 → 退出投屏态
+      if (st == 'STOPPED' || st == 'NO_MEDIA_PRESENT') {
+        _poll?.cancel();
+        _poll = null;
+        _ctrl = null;
+        _current = null;
+        _transport = null;
+        _state = CastState.idle;
+      }
+      notifyListeners();
+    });
+  }
+
+  @override
+  void dispose() {
+    _poll?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/services/cast/dlna_controller.dart
+++ b/lib/services/cast/dlna_controller.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+
+import 'package:http/http.dart' as http;
+
+import 'package:xplayer/services/cast/dlna_device.dart';
+import 'package:xplayer/services/cast/dlna_xml.dart';
+
+/// 面向单台 DLNA 设备的 AVTransport 控制(SetURI/Play/Pause/Stop/状态/进度)。
+class DlnaController {
+  final DlnaDevice device;
+  DlnaController(this.device);
+
+  Future<http.Response> _post(String action, String body) {
+    return http
+        .post(
+          device.controlUrl,
+          headers: {
+            'Content-Type': 'text/xml; charset="utf-8"',
+            'SOAPACTION': soapAction(action),
+          },
+          body: body,
+        )
+        .timeout(const Duration(seconds: 5));
+  }
+
+  /// 设置媒体地址并开始播放。成功返回 true。
+  Future<bool> setUriAndPlay(String url, {required String title}) async {
+    try {
+      final didl = buildDidlLite(title: title, url: url);
+      final r1 = await _post(
+          'SetAVTransportURI', buildSetAvTransportUri(url, didl));
+      if (r1.statusCode != 200) return false;
+      final r2 = await _post('Play', buildPlay());
+      return r2.statusCode == 200;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<bool> play() => _ok('Play', buildPlay());
+  Future<bool> pause() => _ok('Pause', buildPause());
+  Future<bool> stop() => _ok('Stop', buildStop());
+
+  Future<bool> _ok(String action, String body) async {
+    try {
+      final r = await _post(action, body);
+      return r.statusCode == 200;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// 当前传输状态(PLAYING/PAUSED_PLAYBACK/STOPPED/...),失败返回 null。
+  Future<String?> transportState() async {
+    try {
+      final r = await _post('GetTransportInfo', buildGetTransportInfo());
+      if (r.statusCode != 200) return null;
+      return parseTransportState(r.body);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// 当前播放进度,失败返回 null。
+  Future<Duration?> position() async {
+    try {
+      final r = await _post('GetPositionInfo', buildGetPositionInfo());
+      if (r.statusCode != 200) return null;
+      return parsePositionRelTime(r.body);
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/lib/services/cast/dlna_device.dart
+++ b/lib/services/cast/dlna_device.dart
@@ -1,0 +1,23 @@
+/// 一台 DLNA/UPnP MediaRenderer(可投屏的电视/盒子)。
+class DlnaDevice {
+  final String udn; // 唯一标识(uuid:...),用于去重
+  final String friendlyName; // 设备友好名(展示用)
+  final Uri location; // 设备描述文档 URL(SSDP LOCATION)
+  final Uri controlUrl; // AVTransport 服务的控制 URL(已解析为绝对地址)
+
+  const DlnaDevice({
+    required this.udn,
+    required this.friendlyName,
+    required this.location,
+    required this.controlUrl,
+  });
+
+  @override
+  bool operator ==(Object other) => other is DlnaDevice && other.udn == udn;
+
+  @override
+  int get hashCode => udn.hashCode;
+
+  @override
+  String toString() => 'DlnaDevice($friendlyName, $controlUrl)';
+}

--- a/lib/services/cast/dlna_discovery.dart
+++ b/lib/services/cast/dlna_discovery.dart
@@ -1,0 +1,87 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+
+import 'package:xplayer/services/cast/dlna_device.dart';
+import 'package:xplayer/services/cast/dlna_xml.dart';
+
+/// SSDP 发现局域网内的 DLNA MediaRenderer(自写最小实现,无三方依赖)。
+class DlnaDiscovery {
+  static const _ssdpAddr = '239.255.255.250';
+  static const _ssdpPort = 1900;
+
+  String _mSearch(String st) => 'M-SEARCH * HTTP/1.1\r\n'
+      'HOST: $_ssdpAddr:$_ssdpPort\r\n'
+      'MAN: "ssdp:discover"\r\n'
+      'MX: 2\r\n'
+      'ST: $st\r\n\r\n';
+
+  /// 搜索 [timeout] 时长,返回去重后的设备列表。
+  Future<List<DlnaDevice>> search(
+      {Duration timeout = const Duration(seconds: 4)}) async {
+    RawDatagramSocket? socket;
+    final seenLocations = <String>{};
+    final pending = <Future<DlnaDevice?>>[];
+    try {
+      socket = await RawDatagramSocket.bind(InternetAddress.anyIPv4, 0);
+      socket.multicastHops = 4;
+
+      socket.listen((event) {
+        if (event != RawSocketEvent.read) return;
+        final dg = socket!.receive();
+        if (dg == null) return;
+        final resp = String.fromCharCodes(dg.data);
+        final loc = parseSsdpLocation(resp);
+        if (loc == null || !seenLocations.add(loc)) return;
+        pending.add(_resolve(loc));
+      });
+
+      final target = InternetAddress(_ssdpAddr);
+      // 同时搜 MediaRenderer 设备与 AVTransport 服务,兼容只回其一的渲染器;发两轮防丢包。
+      for (final st in const [
+        'urn:schemas-upnp-org:device:MediaRenderer:1',
+        'urn:schemas-upnp-org:service:AVTransport:1',
+      ]) {
+        final pkt = _mSearch(st).codeUnits;
+        socket.send(pkt, target, _ssdpPort);
+        await Future<void>.delayed(const Duration(milliseconds: 150));
+        socket.send(pkt, target, _ssdpPort);
+      }
+
+      await Future<void>.delayed(timeout);
+    } catch (_) {
+      // 多播失败(权限/网络)→ 返回已收集到的
+    } finally {
+      socket?.close();
+    }
+
+    final resolved = await Future.wait(pending);
+    final byUdn = <String, DlnaDevice>{};
+    for (final d in resolved) {
+      if (d != null) byUdn[d.udn] = d;
+    }
+    return byUdn.values.toList();
+  }
+
+  /// 拉取设备描述文档并解析为 DlnaDevice;失败/非 AVTransport 设备返回 null。
+  Future<DlnaDevice?> _resolve(String location) async {
+    try {
+      final uri = Uri.parse(location);
+      final res = await http
+          .get(uri)
+          .timeout(const Duration(seconds: 3));
+      if (res.statusCode != 200) return null;
+      final desc = parseDeviceDescription(res.body, uri);
+      if (desc == null) return null;
+      return DlnaDevice(
+        udn: desc.udn,
+        friendlyName: desc.friendlyName,
+        location: uri,
+        controlUrl: desc.controlUrl,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/lib/services/cast/dlna_xml.dart
+++ b/lib/services/cast/dlna_xml.dart
@@ -1,0 +1,142 @@
+import 'package:xml/xml.dart';
+
+/// DLNA/UPnP AVTransport 的纯函数层:设备描述解析 + SOAP 报文构造 + 响应解析。
+/// 不碰网络,便于单测。
+
+const String kAvTransport = 'urn:schemas-upnp-org:service:AVTransport:1';
+
+/// 设备描述解析结果(从 SSDP LOCATION 文档抽取)。
+class DlnaDescription {
+  final String udn;
+  final String friendlyName;
+  final Uri controlUrl; // AVTransport controlURL,已解析为绝对地址
+  const DlnaDescription(this.udn, this.friendlyName, this.controlUrl);
+}
+
+/// 解析设备描述 XML;无 AVTransport 服务则返回 null。
+/// [location] 为该文档的 URL,用于解析相对的 controlURL / URLBase。
+DlnaDescription? parseDeviceDescription(String xmlStr, Uri location) {
+  late final XmlDocument doc;
+  try {
+    doc = XmlDocument.parse(xmlStr);
+  } catch (_) {
+    return null;
+  }
+
+  String? firstText(String name) {
+    final it = doc.findAllElements(name);
+    return it.isEmpty ? null : it.first.innerText.trim();
+  }
+
+  // 找 AVTransport 服务节点,取其 controlURL
+  String? controlPath;
+  for (final svc in doc.findAllElements('service')) {
+    final type = svc.getElement('serviceType')?.innerText ?? '';
+    if (type.contains('AVTransport')) {
+      controlPath = svc.getElement('controlURL')?.innerText.trim();
+      break;
+    }
+  }
+  if (controlPath == null || controlPath.isEmpty) return null;
+
+  // 基准地址:优先 <URLBase>,否则用 location
+  final urlBase = firstText('URLBase');
+  final base = (urlBase != null && urlBase.isNotEmpty)
+      ? Uri.tryParse(urlBase) ?? location
+      : location;
+  final controlUrl = base.resolve(controlPath);
+
+  final friendly = firstText('friendlyName') ?? 'DLNA 设备';
+  final udn = firstText('UDN') ?? location.toString();
+  return DlnaDescription(udn, friendly, controlUrl);
+}
+
+/// 从 SSDP 响应原文里取 LOCATION 头(大小写不敏感)。
+String? parseSsdpLocation(String response) {
+  for (final line in response.split(RegExp(r'\r?\n'))) {
+    final idx = line.indexOf(':');
+    if (idx <= 0) continue;
+    final key = line.substring(0, idx).trim().toLowerCase();
+    if (key == 'location') return line.substring(idx + 1).trim();
+  }
+  return null;
+}
+
+String _esc(String s) => s
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+
+/// DIDL-Lite 媒体元数据(嵌进 CurrentURIMetaData,需再次转义)。
+/// protocolInfo 用通配,兼容直播/HLS/直链尽量多的渲染器。
+String buildDidlLite({required String title, required String url}) {
+  return '<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" '
+      'xmlns:dc="http://purl.org/dc/elements/1.1/" '
+      'xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">'
+      '<item id="0" parentID="-1" restricted="1">'
+      '<dc:title>${_esc(title)}</dc:title>'
+      '<upnp:class>object.item.videoItem</upnp:class>'
+      '<res protocolInfo="http-get:*:*:*">${_esc(url)}</res>'
+      '</item></DIDL-Lite>';
+}
+
+String _envelope(String action, String inner) {
+  return '<?xml version="1.0" encoding="utf-8"?>'
+      '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" '
+      's:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">'
+      '<s:Body><u:$action xmlns:u="$kAvTransport">'
+      '<InstanceID>0</InstanceID>$inner'
+      '</u:$action></s:Body></s:Envelope>';
+}
+
+/// SOAPACTION 头值。
+String soapAction(String action) => '"$kAvTransport#$action"';
+
+String buildSetAvTransportUri(String url, String didlMetadata) => _envelope(
+    'SetAVTransportURI',
+    '<CurrentURI>${_esc(url)}</CurrentURI>'
+        '<CurrentURIMetaData>${_esc(didlMetadata)}</CurrentURIMetaData>');
+
+String buildPlay() => _envelope('Play', '<Speed>1</Speed>');
+String buildPause() => _envelope('Pause', '');
+String buildStop() => _envelope('Stop', '');
+String buildGetTransportInfo() => _envelope('GetTransportInfo', '');
+String buildGetPositionInfo() => _envelope('GetPositionInfo', '');
+
+/// 从 GetTransportInfo 响应里取 CurrentTransportState
+/// (PLAYING/PAUSED_PLAYBACK/STOPPED/TRANSITIONING/NO_MEDIA_PRESENT)。
+String? parseTransportState(String soapXml) {
+  try {
+    final doc = XmlDocument.parse(soapXml);
+    final e = doc.findAllElements('CurrentTransportState');
+    return e.isEmpty ? null : e.first.innerText.trim();
+  } catch (_) {
+    return null;
+  }
+}
+
+/// 从 GetPositionInfo 响应里取 RelTime(当前进度);解析失败返回 null。
+Duration? parsePositionRelTime(String soapXml) {
+  try {
+    final doc = XmlDocument.parse(soapXml);
+    final e = doc.findAllElements('RelTime');
+    if (e.isEmpty) return null;
+    return _parseHms(e.first.innerText.trim());
+  } catch (_) {
+    return null;
+  }
+}
+
+/// 解析 "H:MM:SS" / "HH:MM:SS.fff" 形式的时间。
+Duration? _parseHms(String s) {
+  final parts = s.split(':');
+  if (parts.length != 3) return null;
+  final h = int.tryParse(parts[0]);
+  final m = int.tryParse(parts[1]);
+  final sec = double.tryParse(parts[2]);
+  if (h == null || m == null || sec == null) return null;
+  return Duration(
+      hours: h, minutes: m, milliseconds: (sec * 1000).round());
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -701,6 +701,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.5"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      sha256: "5a1d2586170e172b8a8c8470bbbffd5eb0cd38a66c0d77155ea138d3af3a4445"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  qr_flutter:
+    dependency: "direct main"
+    description:
+      name: qr_flutter
+      sha256: "5095f0fc6e3f71d08adef8feccc8cea4f12eec18a2e31c2e8d82cb6019f4b097"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   rxdart:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   uuid: ^4.5.1
   permission_handler: ^11.3.1
   file_picker: ^8.0.3
+  qr_flutter: ^4.1.0
 
 dev_dependencies:
   flutter_test:

--- a/test/cast/dlna_xml_test.dart
+++ b/test/cast/dlna_xml_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xplayer/services/cast/dlna_xml.dart';
+
+void main() {
+  group('parseDeviceDescription', () {
+    final location = Uri.parse('http://192.168.1.10:8200/desc.xml');
+
+    test('解析 friendlyName + 相对 controlURL', () {
+      const xml = '''
+<root xmlns="urn:schemas-upnp-org:device-1-0">
+  <device>
+    <friendlyName>客厅电视</friendlyName>
+    <UDN>uuid:abc-123</UDN>
+    <serviceList>
+      <service>
+        <serviceType>urn:schemas-upnp-org:service:RenderingControl:1</serviceType>
+        <controlURL>/rc/control</controlURL>
+      </service>
+      <service>
+        <serviceType>urn:schemas-upnp-org:service:AVTransport:1</serviceType>
+        <controlURL>/avt/control</controlURL>
+      </service>
+    </serviceList>
+  </device>
+</root>''';
+      final d = parseDeviceDescription(xml, location);
+      expect(d, isNotNull);
+      expect(d!.friendlyName, '客厅电视');
+      expect(d.udn, 'uuid:abc-123');
+      expect(d.controlUrl.toString(), 'http://192.168.1.10:8200/avt/control');
+    });
+
+    test('URLBase 优先于 location 解析 controlURL', () {
+      const xml = '''
+<root>
+  <URLBase>http://192.168.1.10:49152/</URLBase>
+  <device>
+    <friendlyName>盒子</friendlyName>
+    <UDN>uuid:x</UDN>
+    <service>
+      <serviceType>urn:schemas-upnp-org:service:AVTransport:1</serviceType>
+      <controlURL>AVTransport/control</controlURL>
+    </service>
+  </device>
+</root>''';
+      final d = parseDeviceDescription(xml, location);
+      expect(d!.controlUrl.toString(),
+          'http://192.168.1.10:49152/AVTransport/control');
+    });
+
+    test('无 AVTransport 服务返回 null', () {
+      const xml = '''
+<root><device><friendlyName>只读设备</friendlyName>
+<service><serviceType>urn:schemas-upnp-org:service:RenderingControl:1</serviceType>
+<controlURL>/rc</controlURL></service></device></root>''';
+      expect(parseDeviceDescription(xml, location), isNull);
+    });
+
+    test('非法 XML 返回 null', () {
+      expect(parseDeviceDescription('<not xml', location), isNull);
+    });
+  });
+
+  group('parseSsdpLocation', () {
+    test('大小写不敏感取 LOCATION', () {
+      const resp = 'HTTP/1.1 200 OK\r\n'
+          'CACHE-CONTROL: max-age=1800\r\n'
+          'Location: http://192.168.1.10:8200/desc.xml\r\n'
+          'ST: urn:schemas-upnp-org:device:MediaRenderer:1\r\n\r\n';
+      expect(parseSsdpLocation(resp), 'http://192.168.1.10:8200/desc.xml');
+    });
+
+    test('无 LOCATION 返回 null', () {
+      expect(parseSsdpLocation('HTTP/1.1 200 OK\r\nST: x\r\n'), isNull);
+    });
+  });
+
+  group('SOAP 构造', () {
+    test('SetAVTransportURI 含转义后的 URL 与内嵌 DIDL', () {
+      final didl = buildDidlLite(title: 'CCTV1 & HD', url: 'http://h/a.m3u8?x=1&y=2');
+      final soap = buildSetAvTransportUri('http://h/a.m3u8?x=1&y=2', didl);
+      expect(soap, contains('<u:SetAVTransportURI'));
+      expect(soap, contains('<InstanceID>0</InstanceID>'));
+      // URL 里的 & 必须转义
+      expect(soap, contains('x=1&amp;y=2'));
+      // DIDL 作为文本内嵌,其尖括号被二次转义
+      expect(soap, contains('&lt;DIDL-Lite'));
+    });
+
+    test('soapAction 头值格式', () {
+      expect(soapAction('Play'),
+          '"urn:schemas-upnp-org:service:AVTransport:1#Play"');
+    });
+  });
+
+  group('响应解析', () {
+    test('parseTransportState', () {
+      const xml = '''
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Body>
+<u:GetTransportInfoResponse xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
+<CurrentTransportState>PLAYING</CurrentTransportState>
+<CurrentTransportStatus>OK</CurrentTransportStatus>
+</u:GetTransportInfoResponse></s:Body></s:Envelope>''';
+      expect(parseTransportState(xml), 'PLAYING');
+    });
+
+    test('parsePositionRelTime 解析 H:MM:SS', () {
+      const xml = '''
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Body>
+<u:GetPositionInfoResponse xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
+<RelTime>0:01:30</RelTime></u:GetPositionInfoResponse></s:Body></s:Envelope>''';
+      expect(parsePositionRelTime(xml), const Duration(minutes: 1, seconds: 30));
+    });
+  });
+}


### PR DESCRIPTION
## DLNA 局域网投屏(手机→电视)
- 自写最小 SSDP 发现 + AVTransport SOAP 控制(无三方依赖,纯函数层 10 单测)
- CastProvider 状态机:发现/投出/暂停·播放·停止/2s 轮询
- 播放页投屏按钮(仅非 TV)+ 设备选择面板;投出成功暂停本地播放
- 图标用 live_tv(按钮 + 弹窗)
- 已真机验证:投屏正常

## TV GitHub 弹窗
- 套 AppTokens 主题色;新增链接二维码(qr_flutter),手机扫码直达

注:投屏面板部分文案暂为中文硬编码,后续补 l10n。