### PR TITLE
fix(tv): 返回键退出 + 菜单键回小窗 + 切后台暂停

### DIFF
--- a/lib/localization/app_en.arb
+++ b/lib/localization/app_en.arb
@@ -160,6 +160,7 @@
   "castStarted": "Casting to {name}",
   "@castStarted": { "placeholders": { "name": { "type": "Object" } } },
   "castFailed": "Cast failed — this device may not support this source",
+  "tvResumeHint": "Press MENU to resume",
   "miniPlayerOnExit": "Mini player on home",
   "miniPlayerOnExitHint": "Keep playing in a corner window when returning home",
   "pipOnLeave": "Picture-in-picture",

--- a/lib/localization/app_localizations.dart
+++ b/lib/localization/app_localizations.dart
@@ -1040,6 +1040,9 @@ abstract class AppLocalizations {
   /// **'Cast failed — this device may not support this source'**
   String get castFailed;
 
+  /// TV 小窗提示:按菜单键回到在播
+  String get tvResumeHint;
+
   /// No description provided for @miniPlayerOnExit.
   ///
   /// In en, this message translates to:

--- a/lib/localization/app_localizations_en.dart
+++ b/lib/localization/app_localizations_en.dart
@@ -518,6 +518,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Cast failed — this device may not support this source';
 
   @override
+  String get tvResumeHint => 'Press MENU to resume';
+
+  @override
   String get miniPlayerOnExit => 'Mini player on home';
 
   @override

--- a/lib/localization/app_localizations_zh.dart
+++ b/lib/localization/app_localizations_zh.dart
@@ -509,6 +509,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get castFailed => '投屏失败,该设备可能不支持此源';
 
   @override
+  String get tvResumeHint => '按 菜单键 继续观看';
+
+  @override
   String get miniPlayerOnExit => '返回小窗续播';
 
   @override

--- a/lib/localization/app_zh.arb
+++ b/lib/localization/app_zh.arb
@@ -160,6 +160,7 @@
     "castStarted": "已投到 {name}",
     "@castStarted": { "placeholders": { "name": { "type": "Object" } } },
     "castFailed": "投屏失败,该设备可能不支持此源",
+    "tvResumeHint": "按 菜单键 继续观看",
     "miniPlayerOnExit": "返回小窗续播",
     "miniPlayerOnExitHint": "从播放页返回首页时,在右下角小窗继续播放",
     "pipOnLeave": "回桌面画中画",

--- a/lib/presentation/screens/home.dart
+++ b/lib/presentation/screens/home.dart
@@ -270,39 +270,45 @@ class _HomeScreenState extends State<HomeScreen> {
         ),
       );
 
+  /// 菜单键:若有小窗续播,回到该频道全屏(复用小窗后端,不重连)。
+  /// TV 遥控器够不到悬浮小窗(浮层在路由焦点域之外),用菜单键作为"回到在播"入口;
+  /// 返回键则回归本职(退出),不再被拦截。
+  void _resumeMini(BuildContext context) {
+    final mini = Provider.of<MiniPlayerController>(context, listen: false);
+    if (!mini.hasMini) return;
+    final ch = mini.channel;
+    final favs = mini.favorites;
+    if (ch == null) return;
+    mini.take();
+    Navigator.of(context).push(MaterialPageRoute(
+      builder: (_) => PlayerScreen(channel: ch, favoriteChannels: favs),
+    ));
+  }
+
   @override
   Widget build(BuildContext context) {
-    return PopScope(
-      canPop: false,
-      onPopInvokedWithResult: (didPop, result) async {
-        if (didPop) return;
-        // 抽屉开着先关抽屉
-        final scaffold = _scaffoldKey.currentState;
-        if (scaffold != null && scaffold.isDrawerOpen) {
-          scaffold.closeDrawer();
-          return;
-        }
-        // TV:遥控器够不到悬浮小窗(浮层在路由焦点域之外),用返回键回到在播频道。
-        // 手机靠点击小窗,这里不拦截(仍走退出确认)。
-        final isTv = Provider.of<GlobalProvider>(context, listen: false).isTV;
-        final mini = Provider.of<MiniPlayerController>(context, listen: false);
-        if (isTv && mini.hasMini) {
-          final ch = mini.channel;
-          final favs = mini.favorites;
-          if (ch != null) {
-            mini.take(); // 切回全屏(浮层隐藏),复用在播 backend
-            Navigator.of(context).push(MaterialPageRoute(
-              builder: (_) =>
-                  PlayerScreen(channel: ch, favoriteChannels: favs),
-            ));
+    return CallbackShortcuts(
+      bindings: {
+        // 菜单键 → 回到正在小窗续播的频道(不占用返回键)
+        const SingleActivator(LogicalKeyboardKey.contextMenu): () =>
+            _resumeMini(context),
+      },
+      child: PopScope(
+        canPop: false,
+        onPopInvokedWithResult: (didPop, result) async {
+          if (didPop) return;
+          // 抽屉开着先关抽屉
+          final scaffold = _scaffoldKey.currentState;
+          if (scaffold != null && scaffold.isDrawerOpen) {
+            scaffold.closeDrawer();
             return;
           }
-        }
-        if (await _confirmExit(context)) {
-          await SystemNavigator.pop();
-        }
-      },
-      child: _buildHome(context),
+          if (await _confirmExit(context)) {
+            await SystemNavigator.pop();
+          }
+        },
+        child: _buildHome(context),
+      ),
     );
   }
 

--- a/lib/presentation/screens/player.dart
+++ b/lib/presentation/screens/player.dart
@@ -68,6 +68,7 @@ class _PlayerScreenState extends State<PlayerScreen>
   bool _inPip = false; // 当前处于系统画中画(Android)
   bool _isTv = false; // TV 不启用系统画中画(系统无 PiP,且用遥控器)
   bool _wakelockOn = false; // 播放中保持屏幕常亮(防 TV 屏保/息屏)
+  bool _resumeAfterBg = false; // 切后台前在播 → 回前台自动恢复
   static const _pipChannel = MethodChannel('native_pip');
   // 信息面板:TV 遥控器上下键滚动(SingleChildScrollView 默认不响应方向键)
   final ScrollController _infoScroll = ScrollController();
@@ -131,6 +132,7 @@ class _PlayerScreenState extends State<PlayerScreen>
       _backend.notifier.addListener(_listenToVideoController);
       _backend.diagnostics?.addListener(_onBackendDiag);
       _playState = PlayState.playing;
+      _backend.play(); // 取回时确保在播(小窗可能因切后台被暂停过)
       _updateWakelock(true); // 从小窗取回已在播 → 直接保持常亮(监听器不会补发)
       WidgetsBinding.instance.addPostFrameCallback((_) => _setSurfaceFullscreen());
     } else {
@@ -180,6 +182,25 @@ class _PlayerScreenState extends State<PlayerScreen>
     super.didUpdateWidget(oldWidget);
     if (widget.channel.id != oldWidget.channel.id) {
       _initializePlayer();
+    }
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (!_hasBackend || _handedOff) return;
+    if (state == AppLifecycleState.resumed) {
+      if (_resumeAfterBg) {
+        _resumeAfterBg = false;
+        _backend.play();
+      }
+    } else if (state == AppLifecycleState.paused ||
+        state == AppLifecycleState.hidden) {
+      // 切后台(如 TV 按 HOME 退桌面)→ 暂停,避免退到后台还在出声;回前台再恢复。
+      if (_backend.notifier.value.isPlaying) {
+        _resumeAfterBg = true;
+        _backend.pause();
+      }
     }
   }
 

--- a/lib/presentation/widgets/mini_player_overlay.dart
+++ b/lib/presentation/widgets/mini_player_overlay.dart
@@ -4,6 +4,7 @@ import 'package:xplayer/providers/mini_player_controller.dart';
 import 'package:xplayer/providers/global_provider.dart';
 import 'package:xplayer/presentation/screens/player.dart';
 import 'package:xplayer/shared/navigation.dart';
+import 'package:xplayer/localization/app_localizations.dart';
 
 /// 全局右下角小窗。mode==mini 时显示;点击展开回全屏,X 关闭。
 class MiniPlayerOverlay extends StatelessWidget {
@@ -17,6 +18,7 @@ class MiniPlayerOverlay extends StatelessWidget {
         final media = MediaQuery.of(context);
         final card = miniCardRect(media.size, media.padding);
         final isTv = Provider.of<GlobalProvider>(context, listen: false).isTV;
+        final l = AppLocalizations.of(context)!;
         void expand() {
           final ch = c.channel;
           if (ch == null) return;
@@ -53,10 +55,10 @@ class MiniPlayerOverlay extends StatelessWidget {
                           onTap: expand,
                           child: isTv
                               // TV 遥控器够不到浮层,提示用返回键回到在播频道
-                              ? const Align(
+                              ? Align(
                                   alignment: Alignment.centerLeft,
-                                  child: Text('按 返回键 继续观看',
-                                      style: TextStyle(
+                                  child: Text(l.tvResumeHint,
+                                      style: const TextStyle(
                                           color: Colors.white70, fontSize: 11)),
                                 )
                               : const Align(

--- a/lib/providers/mini_player_controller.dart
+++ b/lib/providers/mini_player_controller.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart' show Rect, Size, EdgeInsets;
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart' show WidgetsBinding, WidgetsBindingObserver, AppLifecycleState;
 import 'package:xplayer/data/models/channel_model.dart';
 import 'package:xplayer/services/player/x_player_backend.dart';
 
@@ -31,11 +32,31 @@ Rect miniVideoRect(Size screen, EdgeInsets padding) {
 /// 跨路由持有播放器 backend,实现返回首页后的小窗续播。
 /// 「交接」模型:PlayerScreen 全屏时驱动 backend;返回时 enterMini 把 backend 交给本控制器
 /// (不销毁);重开时 take() 取回。
-class MiniPlayerController extends ChangeNotifier {
+class MiniPlayerController extends ChangeNotifier with WidgetsBindingObserver {
+  MiniPlayerController() {
+    WidgetsBinding.instance.addObserver(this);
+  }
+
   XPlayerBackend? _backend;
   Channel? _channel;
   List<Channel> _favorites = const [];
   PlayerMode _mode = PlayerMode.none;
+
+  /// 切后台(如按 HOME 退到电视桌面)时,暂停小窗续播,避免后台还在出声。
+  /// 全屏播放页的暂停由 PlayerScreen 自己处理,这里只管小窗态。
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.paused ||
+        state == AppLifecycleState.hidden) {
+      if (hasMini) _backend?.pause();
+    }
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
 
   XPlayerBackend? get backend => _backend;
   Channel? get channel => _channel;


### PR DESCRIPTION
TV 体验三修(均不影响手机):
1. **返回键能退出**:去掉首页'返回=回到播放页'的拦截,返回键回归退出/返回本职。
2. **菜单键回在播**:小窗续播时按 MENU 键回到该频道(复用后端秒回全屏);小窗提示改为'按菜单键继续观看'。小窗在路由焦点域外、D-pad 够不到是架构限制,故用菜单键而非'选中小窗'。
3. **切后台暂停**:按 HOME 退到电视桌面时暂停播放——播放页(回前台自动恢复)+ 首页小窗 双覆盖,不再后台出声。