### PR TITLE
fix(tv): 菜单键冲突 + 操作栏自动消失重置 + 切台返回先关操作栏

### DIFF
--- a/lib/presentation/screens/player.dart
+++ b/lib/presentation/screens/player.dart
@@ -217,6 +217,7 @@ class _PlayerScreenState extends State<PlayerScreen>
     _focusNode.dispose();
     _infoScroll.dispose();
     _infoFocus.dispose();
+    FocusManager.instance.removeListener(_resetAutoCloseOnFocus);
     if (_wakelockOn) WakelockPlus.disable(); // 离开播放页 → 解除常亮
     _wakelockOn = false;
     if (Platform.isAndroid) {
@@ -551,6 +552,10 @@ class _PlayerScreenState extends State<PlayerScreen>
     // 仅逻辑标记,build() 不读它 —— 不用 setState,避免控制条弹出时整页重建/视频闪一下
     _controlsVisible = true;
 
+    // 操作栏开启期间监听焦点变化:切换按钮(遥控器移动焦点)即重置 5s 自动收起,
+    // 避免正在浏览按钮时操作栏被收掉。
+    FocusManager.instance.addListener(_resetAutoCloseOnFocus);
+
     showGeneralDialog(
       context: context,
       barrierDismissible: true,
@@ -630,9 +635,15 @@ class _PlayerScreenState extends State<PlayerScreen>
       },
     ).then((value) {
       cancelAutoCloseTimer();
+      FocusManager.instance.removeListener(_resetAutoCloseOnFocus);
       // 同上:不 setState,关闭控制条时不触发整页重建
       _controlsVisible = false;
     });
+  }
+
+  /// 操作栏开启期间,焦点变化(切换按钮)即重置自动收起倒计时。
+  void _resetAutoCloseOnFocus() {
+    if (_controlsVisible) _startAutoCloseTimer();
   }
 
   /// 解析某频道应播放的源:优先用户记住的源(仍在列表中时),否则第一个。
@@ -1165,6 +1176,15 @@ class _PlayerScreenState extends State<PlayerScreen>
       canPop: false,
       onPopInvokedWithResult: (didPop, _) {
         if (didPop) return;
+        // 操作栏开着时,返回键应先关操作栏,而不是直接退到首页。
+        // (操作栏是顶层对话框路由会自行关闭;但切台等场景会留下 _controlsVisible
+        //  残留为 true,此时返回落到播放页 → 先吞掉并复位,不退出。)
+        if (_controlsVisible) {
+          cancelAutoCloseTimer();
+          _controlsVisible = false;
+          if (mounted) setState(() {});
+          return;
+        }
         _handleBack();
       },
       child: RawKeyboardListener(

--- a/lib/presentation/widgets/channel_item_widget.dart
+++ b/lib/presentation/widgets/channel_item_widget.dart
@@ -62,6 +62,8 @@ class _ChannelItemWidgetState extends State<ChannelItemWidget> {
         },
         onMore: () =>
             ChannelActions.handleMoreAction(context, widget.channel, () {}),
+        // 菜单键留给首页"回到在播小窗";频道"更多操作"仍可长按 OK 触发,避免与之冲突
+        menuKeyAsMore: false,
         child: (isFocused) => SizedBox(
             width: widget.width,
             child: Stack(children: [

--- a/lib/shared/components/x_base_button.dart
+++ b/lib/shared/components/x_base_button.dart
@@ -20,6 +20,10 @@ class XBaseButton extends StatefulWidget {
   final VoidCallback? onArrowDown;
   final VoidCallback? onArrowLeft;
   final VoidCallback? onArrowRight;
+  /// 菜单键(MENU/contextMenu)是否触发 onMore。默认 true;
+  /// 设 false 时菜单键不被本按钮消费(可让上层用菜单键做别的,如"回到在播小窗"),
+  /// onMore 仍可通过长按 OK 触发。
+  final bool menuKeyAsMore;
 
   const XBaseButton({
     Key? key,
@@ -33,6 +37,7 @@ class XBaseButton extends StatefulWidget {
     this.onArrowDown,
     this.onArrowLeft,
     this.onArrowRight,
+    this.menuKeyAsMore = true,
   }) : super(key: key);
 
   @override
@@ -136,8 +141,9 @@ class _XBaseButtonState extends State<XBaseButton> with WidgetsBindingObserver {
         updateStart(DateTime.now());
       }
     }
-    // TV端菜单事件
+    // TV端菜单事件(menuKeyAsMore=false 时不消费菜单键,留给上层做"回到在播"等)
     if (widget.onMore != null &&
+        widget.menuKeyAsMore &&
         (event.logicalKey == LogicalKeyboardKey.contextMenu)) {
       widget.onMore!();
     }


### PR DESCRIPTION
1. **菜单键冲突**:首页频道项菜单键不再触发'更多操作'(给 XBaseButton 加 menuKeyAsMore=false),菜单键专做'回到在播小窗';频道更多操作仍可长按 OK。
2. **操作栏自动消失重置**:操作栏开启期间监听焦点变化,切换按钮即重置 5s 倒计时(原 onFocusChange 从未被调用)。
3. **切台后返回**:操作栏开着时返回键先关操作栏(修 _controlsVisible 残留导致返回直接退首页)。