### PR TITLE
feat(tv): 交互优化(焦点落点 / 切台OSD / 数字键选台 / 按钮排序)

### DIFF
--- a/lib/presentation/screens/player.dart
+++ b/lib/presentation/screens/player.dart
@@ -69,6 +69,11 @@ class _PlayerScreenState extends State<PlayerScreen>
   bool _isTv = false; // TV 不启用系统画中画(系统无 PiP,且用遥控器)
   bool _wakelockOn = false; // 播放中保持屏幕常亮(防 TV 屏保/息屏)
   bool _resumeAfterBg = false; // 切后台前在播 → 回前台自动恢复
+  // 切台信息浮层(OSD)+ 数字键选台
+  bool _zapOsdVisible = false;
+  Timer? _zapOsdTimer;
+  String _numberInput = '';
+  Timer? _numberTimer;
   static const _pipChannel = MethodChannel('native_pip');
   // 信息面板:TV 遥控器上下键滚动(SingleChildScrollView 默认不响应方向键)
   final ScrollController _infoScroll = ScrollController();
@@ -209,6 +214,8 @@ class _PlayerScreenState extends State<PlayerScreen>
     _retryTimer?.cancel();
     _bufferingTimer?.cancel();
     autoCloseTimer?.cancel();
+    _zapOsdTimer?.cancel();
+    _numberTimer?.cancel();
     _backend.notifier.removeListener(_listenToVideoController);
     _backend.diagnostics?.removeListener(_onBackendDiag);
     useSurfaceView.removeListener(_onRenderModeChanged);
@@ -676,10 +683,52 @@ class _PlayerScreenState extends State<PlayerScreen>
       _audioTracks = [];
     });
 
+    _flashZapOsd(); // 切台信息浮层
     _initializePlayer();
   }
 
+  /// 切台信息浮层(OSD):台标 + 频道名 + 当前/下一节目,显示 ~2.5s。
+  void _flashZapOsd() {
+    if (!mounted) return;
+    setState(() => _zapOsdVisible = true);
+    _zapOsdTimer?.cancel();
+    _zapOsdTimer = Timer(const Duration(milliseconds: 2500), () {
+      if (mounted) setState(() => _zapOsdVisible = false);
+    });
+  }
+
+  /// 数字键输入(选台):累积数字,1.8s 后跳到对应频道号。
+  void _onChannelDigit(int d) {
+    _numberInput = '$_numberInput$d';
+    if (_numberInput.length > 4) {
+      _numberInput = _numberInput.substring(_numberInput.length - 4);
+    }
+    setState(() {});
+    _numberTimer?.cancel();
+    _numberTimer = Timer(const Duration(milliseconds: 1800), _commitChannelNumber);
+  }
+
+  void _commitChannelNumber() {
+    final n = int.tryParse(_numberInput);
+    _numberInput = '';
+    if (mounted) setState(() {});
+    if (n == null || _channels.isEmpty) return;
+    final idx = (n - 1).clamp(0, _channels.length - 1); // 频道号 1-based
+    if (idx != _currentIndex) _switchChannel(idx - _currentIndex);
+  }
+
   void _handleKeyPress(RawKeyEvent event) {
+    // 数字键选台:遥控器数字键累积输入频道号
+    if (event is RawKeyDownEvent) {
+      final lbl = event.logicalKey.keyLabel;
+      if (lbl.length == 1) {
+        final c = lbl.codeUnitAt(0);
+        if (c >= 0x30 && c <= 0x39) {
+          _onChannelDigit(c - 0x30);
+          return;
+        }
+      }
+    }
     if (event is RawKeyUpEvent &&
         (event.logicalKey == LogicalKeyboardKey.select ||
             event.logicalKey == LogicalKeyboardKey.contextMenu)) {
@@ -1286,11 +1335,112 @@ class _PlayerScreenState extends State<PlayerScreen>
                   ],
                 ),
               ),
+              // 切台信息浮层(OSD):台标 + 频道名 + 当前/下一节目
+              if (_zapOsdVisible)
+                Positioned(
+                  left: 24,
+                  top: 24,
+                  child: IgnorePointer(child: _buildZapOsd()),
+                ),
+              // 数字键选台:输入中的频道号
+              if (_numberInput.isNotEmpty)
+                Positioned(
+                  right: 24,
+                  top: 24,
+                  child: IgnorePointer(
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 20, vertical: 10),
+                      decoration: BoxDecoration(
+                        color: Colors.black.withOpacity(0.7),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Text(
+                        _numberInput,
+                        style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 40,
+                            fontWeight: FontWeight.bold,
+                            decoration: TextDecoration.none),
+                      ),
+                    ),
+                  ),
+                ),
             ],
           ),
         ),
       ),
     ),
+    );
+  }
+
+  /// 切台信息浮层内容:台标 + 序号·频道名 + 当前/下一节目。
+  Widget _buildZapOsd() {
+    final info = programmeInfo;
+    final cur = info.$2;
+    final next = info.$3;
+    return Material(
+      color: Colors.transparent,
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 440),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        decoration: BoxDecoration(
+          color: Colors.black.withOpacity(0.72),
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (_channel.logo != null && _channel.logo!.isNotEmpty) ...[
+              CachedNetworkImage(
+                imageUrl: _channel.logo!,
+                height: 44,
+                fit: BoxFit.contain,
+                errorWidget: (_, __, ___) => const SizedBox(width: 0),
+              ),
+              const SizedBox(width: 12),
+            ],
+            Flexible(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '${_currentIndex + 1}. ${_channel.name.isNotEmpty ? _channel.name : _channel.id}',
+                    style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                        decoration: TextDecoration.none),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (cur != null)
+                    Text(
+                      cur.title,
+                      style: const TextStyle(
+                          color: Colors.white70,
+                          fontSize: 13,
+                          decoration: TextDecoration.none),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  if (next != null)
+                    Text(
+                      '${AppLocalizations.of(context)!.epgNext} ${next.title}',
+                      style: const TextStyle(
+                          color: Colors.white38,
+                          fontSize: 12,
+                          decoration: TextDecoration.none),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/presentation/widgets/audio_track_selector_widget.dart
+++ b/lib/presentation/widgets/audio_track_selector_widget.dart
@@ -31,6 +31,7 @@ class AudioTrackSelectorWidget extends StatelessWidget {
                 text: label,
                 size: XTextButtonSize.large,
                 width: 200,
+                autofocus: t.isSelected, // 打开即聚焦当前音轨
                 textStyle: const TextStyle(fontSize: 13),
                 type: t.isSelected
                     ? XTextButtonType.primary

--- a/lib/presentation/widgets/channel_source_widget.dart
+++ b/lib/presentation/widgets/channel_source_widget.dart
@@ -71,6 +71,7 @@ class _ChannelSourceWidgetState extends State<ChannelSourceWidget> {
                   text: getName(e.title),
                   size: XTextButtonSize.large,
                   width: 160,
+                  autofocus: isSelected, // 打开即聚焦当前源
                   onPressed: () {
                     if (!isSelected && widget.onSourceSwitch != null) {
                       widget.onSourceSwitch!(e.link);

--- a/lib/presentation/widgets/player_actions_widget.dart
+++ b/lib/presentation/widgets/player_actions_widget.dart
@@ -310,10 +310,12 @@ class _PlayerActionsWidgetState extends State<PlayerActionsWidget>
     );
 
     // 操作按钮组(两种布局共用同一组按钮)
+    final hasError = widget.backend.notifier.value.hasError;
     final actionButtons = <Widget>[
-      if (widget.backend.notifier.value.hasError) ...[
+      if (hasError) ...[
         XIconButton(
           icon: Icons.refresh,
+          autofocus: true, // 出错时操作栏打开默认聚焦"重试"
           onPressed: () {
             if (widget.onRetryInit != null) {
               widget.onRetryInit!();
@@ -324,7 +326,18 @@ class _PlayerActionsWidgetState extends State<PlayerActionsWidget>
       ],
       XIconButton(
         onPressed: _handlePlayPause,
+        autofocus: !hasError, // 正常时操作栏打开默认聚焦"播放/暂停"
         icon: _isPlaying ? Icons.pause : Icons.play_arrow,
+      ),
+      const SizedBox(width: 8),
+      // 收藏:常用,排前
+      XIconButton(
+        onPressed: () async {
+          await widget.onFavorite();
+          _updateIsFavorite();
+        },
+        iconColor: _isFavorite ? Colors.red : Colors.white,
+        icon: _isFavorite ? Icons.favorite : Icons.favorite_outline,
       ),
       const SizedBox(width: 8),
       XIconButton(
@@ -392,15 +405,6 @@ class _PlayerActionsWidgetState extends State<PlayerActionsWidget>
             widget.onToggleDiag!();
           }
         },
-      ),
-      const SizedBox(width: 8),
-      XIconButton(
-        onPressed: () async {
-          await widget.onFavorite();
-          _updateIsFavorite();
-        },
-        iconColor: _isFavorite ? Colors.red : Colors.white,
-        icon: _isFavorite ? Icons.favorite : Icons.favorite_outline,
       ),
       if (isMobile) const SizedBox(width: 8),
       if (isMobile)

--- a/lib/presentation/widgets/player_dialogs.dart
+++ b/lib/presentation/widgets/player_dialogs.dart
@@ -202,6 +202,7 @@ class PlayerDialogs {
                   text: o.$1,
                   size: XTextButtonSize.large,
                   width: 180,
+                  autofocus: selected, // 打开即聚焦当前项
                   textStyle: const TextStyle(fontSize: 13),
                   type: selected
                       ? XTextButtonType.primary

--- a/lib/presentation/widgets/quality_selector_widget.dart
+++ b/lib/presentation/widgets/quality_selector_widget.dart
@@ -40,6 +40,7 @@ class QualitySelectorWidget extends StatelessWidget {
           text: text,
           size: XTextButtonSize.large,
           width: 180,
+          autofocus: selected, // 打开即聚焦当前画质
           // 字号调小,避免「1080P · 4.9 Mbps」溢出换行
           textStyle: const TextStyle(fontSize: 13),
           onPressed: () {

--- a/lib/shared/components/x_base_button.dart
+++ b/lib/shared/components/x_base_button.dart
@@ -24,6 +24,8 @@ class XBaseButton extends StatefulWidget {
   /// 设 false 时菜单键不被本按钮消费(可让上层用菜单键做别的,如"回到在播小窗"),
   /// onMore 仍可通过长按 OK 触发。
   final bool menuKeyAsMore;
+  /// 挂载时自动获取焦点(TV:弹窗打开后焦点落到当前项/默认按钮)
+  final bool autofocus;
 
   const XBaseButton({
     Key? key,
@@ -38,6 +40,7 @@ class XBaseButton extends StatefulWidget {
     this.onArrowLeft,
     this.onArrowRight,
     this.menuKeyAsMore = true,
+    this.autofocus = false,
   }) : super(key: key);
 
   @override
@@ -245,6 +248,7 @@ class _XBaseButtonState extends State<XBaseButton> with WidgetsBindingObserver {
       onLongPress: _handleLongPress, // 触控屏长按
       child: RawKeyboardListener(
         focusNode: _focusNode,
+        autofocus: widget.autofocus,
         onKey: _handleKeyPress,
         child: Listener(
           onPointerDown: _handleRightClick,

--- a/lib/shared/components/x_icon_button.dart
+++ b/lib/shared/components/x_icon_button.dart
@@ -16,6 +16,7 @@ class XIconButton extends StatelessWidget {
   final bool hoverBgOnly;
   final String? tooltipMessage;
   final FocusNode? focusNode;
+  final bool autofocus;
 
   const XIconButton(
       {Key? key,
@@ -28,7 +29,8 @@ class XIconButton extends StatelessWidget {
       this.buttonSize = XIconButtonSize.defaultSize,
       this.hoverBgOnly = false,
       this.tooltipMessage,
-      this.focusNode})
+      this.focusNode,
+      this.autofocus = false})
       : super(key: key);
 
   Color _getBackgroundColor(BuildContext context, bool isFocus) {
@@ -62,6 +64,7 @@ class XIconButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return XBaseButton(
       focusNode: focusNode,
+      autofocus: autofocus,
       tooltipMessage: tooltipMessage,
       onPressed: onPressed,
       child: (bool isFocus) {

--- a/lib/shared/components/x_text_button.dart
+++ b/lib/shared/components/x_text_button.dart
@@ -22,6 +22,7 @@ class XTextButton extends StatelessWidget {
   final VoidCallback? onArrowDown;
   final VoidCallback? onArrowLeft;
   final VoidCallback? onArrowRight;
+  final bool autofocus;
 
   const XTextButton(
       {Key? key,
@@ -39,7 +40,8 @@ class XTextButton extends StatelessWidget {
       this.onArrowUp,
       this.onArrowDown,
       this.onArrowLeft,
-      this.onArrowRight})
+      this.onArrowRight,
+      this.autofocus = false})
       : super(key: key);
 
   Color _getBackgroundColor(BuildContext context, bool isFocus) {
@@ -109,6 +111,7 @@ class XTextButton extends StatelessWidget {
     return XBaseButton(
       tooltipMessage: tooltipMessage,
       focusNode: focusNode,
+      autofocus: autofocus,
       onPressed: onPressed,
       onMore: onMore,
       onArrowUp: onArrowUp,


### PR DESCRIPTION
1. **操作栏默认焦点**:打开操作栏自动聚焦 播放/暂停(出错时聚焦重试)——给 XBaseButton/XIconButton/XTextButton 加 autofocus。
2. **弹窗聚焦当前项**:源切换/画质/音轨/睡眠 打开即聚焦当前选中项(频道列表本就如此,现统一)。
3. **切台信息浮层 OSD**:↑↓ 切台时显示 台标+序号·频道名+当前/下一节目,~2.5s 自动消失,解决盲切。
5. **数字键选台**:遥控器数字键输入频道号直达(1.8s 提交,配合 OSD)。
6. **操作栏按钮排序**:收藏移到靠前。

(#4 取消:← 已呼出频道列表;#7 取消:切台已有 OSD。)