### PR TITLE
fix(tv): 焦点按钮更明显 + 操作栏/源等面板背景更实

### DIFF
--- a/lib/presentation/widgets/player_actions_widget.dart
+++ b/lib/presentation/widgets/player_actions_widget.dart
@@ -419,8 +419,8 @@ class _PlayerActionsWidgetState extends State<PlayerActionsWidget>
       child: Container(
         width: double.infinity,
         height: min(MediaQuery.of(context).size.height, 130),
-        // 通栏淡灰底:无圆角、无边框,与视频画面区分但不抢眼
-        color: const Color.fromRGBO(48, 48, 48, 0.55),
+        // 通栏底:加深、提高不透明度,叠在视频上也清晰可辨
+        color: const Color.fromRGBO(20, 20, 20, 0.92),
         padding: const EdgeInsets.symmetric(horizontal: 16.0),
         child: wide
             // 宽屏:频道信息占左侧,按钮组靠右,填满右侧空白

--- a/lib/presentation/widgets/player_dialogs.dart
+++ b/lib/presentation/widgets/player_dialogs.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:xplayer/data/models/channel_model.dart';
-import 'package:xplayer/data/models/programme_model.dart';
 import 'package:xplayer/presentation/widgets/channel_selector_widget.dart';
 import 'package:xplayer/presentation/widgets/channel_source_widget.dart';
 import 'package:xplayer/presentation/widgets/quality_selector_widget.dart';
@@ -77,7 +76,7 @@ class PlayerDialogs {
             width: max(200, MediaQuery.of(context).size.width * 0.3),
             height: MediaQuery.of(context).size.height * 1.0,
             decoration: BoxDecoration(
-              color: const Color.fromRGBO(0, 0, 0, 0.3),
+              color: const Color.fromRGBO(20, 20, 20, 0.92),
               borderRadius: BorderRadius.circular(16.0),
             ),
             child: ChannelSourceWidget(
@@ -119,7 +118,7 @@ class PlayerDialogs {
             width: max(220, MediaQuery.of(context).size.width * 0.3),
             height: MediaQuery.of(context).size.height * 1.0,
             decoration: BoxDecoration(
-              color: const Color.fromRGBO(0, 0, 0, 0.3),
+              color: const Color.fromRGBO(20, 20, 20, 0.92),
               borderRadius: BorderRadius.circular(16.0),
             ),
             child: QualitySelectorWidget(
@@ -155,7 +154,7 @@ class PlayerDialogs {
           width: max(220, MediaQuery.of(context).size.width * 0.3),
           height: MediaQuery.of(context).size.height,
           decoration: BoxDecoration(
-            color: const Color.fromRGBO(0, 0, 0, 0.3),
+            color: const Color.fromRGBO(20, 20, 20, 0.92),
             borderRadius: BorderRadius.circular(16.0),
           ),
           child: child,

--- a/lib/shared/components/x_icon_button.dart
+++ b/lib/shared/components/x_icon_button.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:xplayer/shared/components/x_base_button.dart';
+import 'package:xplayer/shared/theme/app_tokens.dart';
 
 enum XIconButtonType { defaultType, primary, danger }
 
@@ -44,9 +45,7 @@ class XIconButton extends StatelessWidget {
         return isFocus ? Colors.red.withOpacity(0.75) : Colors.red;
       case XIconButtonType.defaultType:
       default:
-        return isFocus
-            ? Colors.white.withOpacity(0.25)
-            : Colors.white.withOpacity(0.15);
+        return isFocus ? AppTokens.focusFillDefault : AppTokens.fillDefault;
     }
   }
 
@@ -77,6 +76,10 @@ class XIconButton extends StatelessWidget {
           decoration: BoxDecoration(
             color: _getBackgroundColor(context, isFocus),
             borderRadius: BorderRadius.circular(24.0),
+            // 焦点态加品牌绿描边,TV 上一眼看出选中的是哪个
+            border: isFocus
+                ? Border.all(color: AppTokens.focusRing, width: 2)
+                : null,
           ),
           alignment: Alignment.center,
           child: Icon(

--- a/lib/shared/components/x_text_button.dart
+++ b/lib/shared/components/x_text_button.dart
@@ -131,6 +131,10 @@ class XTextButton extends StatelessWidget {
           decoration: BoxDecoration(
             color: _getBackgroundColor(context, isFocus),
             borderRadius: BorderRadius.circular(24.0),
+            // 焦点态品牌绿描边,选中项一眼可辨
+            border: isFocus
+                ? Border.all(color: AppTokens.focusRing, width: 2)
+                : null,
             boxShadow: isFocus
                 ? [
                     BoxShadow(


### PR DESCRIPTION
1. **焦点不明显**:焦点按钮加**品牌绿描边**(focusRing)并改用主题填充色——XIconButton 原来只是白底 0.25 vs 0.15 几乎看不出。现在 TV 上一眼看出选中哪个按钮(操作栏、源/画质/音轨/睡眠弹窗、首页顶栏图标统一)。
2. **面板太透**:操作栏背景 0.55→0.92(加深)、源/画质/音轨/睡眠面板 0.3→0.92,叠在视频上也清晰。频道列表(0.55)按你说的保留不动。
3. 顺手移除 player_dialogs 一个未用 import。