### PR TITLE
fix(tv/mobile): 焦点态纯背景色 + 竖屏操作栏贴底 + 源选择浮层滚动/SafeArea

### DIFF
--- a/lib/presentation/widgets/channel_source_widget.dart
+++ b/lib/presentation/widgets/channel_source_widget.dart
@@ -56,9 +56,10 @@ class _ChannelSourceWidgetState extends State<ChannelSourceWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
+    // 源较多时可纵向滚动,避免超出浮层被裁切
+    return SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(vertical: 16),
         child: Column(
-      mainAxisAlignment: MainAxisAlignment.center,
       children: sources.map((e) {
         final isSelected = widget.link == e.link;
 

--- a/lib/presentation/widgets/player_actions_widget.dart
+++ b/lib/presentation/widgets/player_actions_widget.dart
@@ -446,7 +446,10 @@ class _PlayerActionsWidgetState extends State<PlayerActionsWidget>
                 ],
               )
             // 窄屏:信息在上、按钮在下;按钮可能多于一屏宽 → 横向可滚动,避免溢出
+            // mainAxisSize.min:否则 Column 撑满全屏高度,会让操作栏内容居中、
+            // 外层 Align(bottomCenter) 失效(竖屏时操作栏跑到屏幕中间)。
             : Column(
+                mainAxisSize: MainAxisSize.min,
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   infoRow,

--- a/lib/presentation/widgets/player_dialogs.dart
+++ b/lib/presentation/widgets/player_dialogs.dart
@@ -78,10 +78,13 @@ class PlayerDialogs {
             decoration: const BoxDecoration(
               color: Color.fromRGBO(48, 48, 48, 0.86),
             ),
-            child: ChannelSourceWidget(
-              channel: channel,
-              link: link,
-              onSourceSwitch: onSourceSwitch,
+            // SafeArea:竖屏时不被状态栏/刘海遮挡
+            child: SafeArea(
+              child: ChannelSourceWidget(
+                channel: channel,
+                link: link,
+                onSourceSwitch: onSourceSwitch,
+              ),
             ),
           ),
         );

--- a/lib/shared/components/x_icon_button.dart
+++ b/lib/shared/components/x_icon_button.dart
@@ -82,15 +82,6 @@ class XIconButton extends StatelessWidget {
           decoration: BoxDecoration(
             color: _getBackgroundColor(context, isFocus),
             borderRadius: BorderRadius.circular(24.0),
-            boxShadow: isFocus
-                ? [
-                    BoxShadow(
-                      color: AppTokens.focusRing.withOpacity(0.45),
-                      blurRadius: 16,
-                      spreadRadius: 1,
-                    ),
-                  ]
-                : null,
           ),
           alignment: Alignment.center,
           child: Icon(
@@ -126,13 +117,8 @@ class XIconButton extends StatelessWidget {
                 ],
               );
 
-        // 焦点态轻微放大,包裹整体(图标+文字一起放大)
-        return AnimatedScale(
-          scale: isFocus ? 1.08 : 1.0,
-          duration: const Duration(milliseconds: 150),
-          curve: Curves.easeOut,
-          child: content,
-        );
+        // 焦点态仅用背景色区分(不放大/不发光,避免在受限容器内被裁剪)
+        return content;
       },
     );
   }

--- a/lib/shared/components/x_text_button.dart
+++ b/lib/shared/components/x_text_button.dart
@@ -119,41 +119,27 @@ class XTextButton extends StatelessWidget {
       onArrowLeft: onArrowLeft,
       onArrowRight: onArrowRight,
       child: (bool isFocus) {
-        return AnimatedScale(
-          scale: isFocus ? 1.08 : 1.0,
-          duration: const Duration(milliseconds: 150),
-          curve: Curves.easeOut,
-          child: Container(
-            width: _getWidth(),
-            // 用 minHeight 而非固定 height:文字一行放不下换行时容器可增高,不裁切
-            constraints: BoxConstraints(minHeight: _getHeight()),
-            padding: padding ??
-                EdgeInsets.symmetric(
-                  horizontal: (size == XTextButtonSize.defaultSize ||
-                               size == XTextButtonSize.flexible) ? 16.0 : 32.0,
-                ),
-            // 焦点态:轻微放大 + 品牌色柔光,去掉生硬描边
-            decoration: BoxDecoration(
-              color: _getBackgroundColor(context, isFocus),
-              borderRadius: BorderRadius.circular(24.0),
-              boxShadow: isFocus
-                  ? [
-                      BoxShadow(
-                        color: AppTokens.focusRing.withOpacity(0.45),
-                        blurRadius: 16,
-                        spreadRadius: 1,
-                      ),
-                    ]
-                  : null,
-            ),
-            alignment: Alignment.center,
-            child: Text(
-              text,
-              style: _getTextStyle(context),
-              textAlign: TextAlign.center,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-            ),
+        // 焦点态仅用背景色区分(不放大/不发光,避免被裁剪)
+        return Container(
+          width: _getWidth(),
+          // 用 minHeight 而非固定 height:文字一行放不下换行时容器可增高,不裁切
+          constraints: BoxConstraints(minHeight: _getHeight()),
+          padding: padding ??
+              EdgeInsets.symmetric(
+                horizontal: (size == XTextButtonSize.defaultSize ||
+                             size == XTextButtonSize.flexible) ? 16.0 : 32.0,
+              ),
+          decoration: BoxDecoration(
+            color: _getBackgroundColor(context, isFocus),
+            borderRadius: BorderRadius.circular(24.0),
+          ),
+          alignment: Alignment.center,
+          child: Text(
+            text,
+            style: _getTextStyle(context),
+            textAlign: TextAlign.center,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
           ),
         );
       },


### PR DESCRIPTION
修复 2.5.7 反馈的问题:

1. **焦点态去掉放大+发光**,改为仅用背景色区分(XIconButton / XTextButton)——之前的放大和柔光在受限容器内被裁剪。
2. **竖屏操作栏贴底**:窄屏 Column 加 `mainAxisSize.min`,否则 Column 撑满全屏导致内容居中、Align(bottomCenter) 失效(操作栏跑到屏幕中间)。
3. **源选择浮层**:ChannelSourceWidget 改为 SingleChildScrollView(源多时可滚动,不再裁切);浮层加 SafeArea(竖屏不被状态栏/刘海遮挡)。