### PR TITLE
feat(theme): 主题色设定 + 抽屉导航重排

### DIFF
--- a/lib/localization/app_en.arb
+++ b/lib/localization/app_en.arb
@@ -126,6 +126,7 @@
   "reloadingAttempt": "Reloading… (attempt {count})",
   "filterTitle": "Search & Filter",
   "itemSize": "Item Size",
+  "themeColor": "Theme color",
   "noProgramme": "No programme guide for this channel",
   "exitAppTitle": "Exit App",
   "exitAppMessage": "Are you sure you want to exit?",

--- a/lib/localization/app_localizations.dart
+++ b/lib/localization/app_localizations.dart
@@ -854,6 +854,12 @@ abstract class AppLocalizations {
   /// **'Item Size'**
   String get itemSize;
 
+  /// No description provided for @themeColor.
+  ///
+  /// In en, this message translates to:
+  /// **'Theme color'**
+  String get themeColor;
+
   /// No description provided for @noProgramme.
   ///
   /// In en, this message translates to:

--- a/lib/localization/app_localizations_en.dart
+++ b/lib/localization/app_localizations_en.dart
@@ -414,6 +414,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get itemSize => 'Item Size';
 
   @override
+  String get themeColor => 'Theme color';
+
+  @override
   String get noProgramme => 'No programme guide for this channel';
 
   @override

--- a/lib/localization/app_localizations_zh.dart
+++ b/lib/localization/app_localizations_zh.dart
@@ -408,6 +408,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get itemSize => '显示大小';
 
   @override
+  String get themeColor => '主题色';
+
+  @override
   String get noProgramme => '该频道暂无节目单';
 
   @override

--- a/lib/localization/app_zh.arb
+++ b/lib/localization/app_zh.arb
@@ -126,6 +126,7 @@
     "reloadingAttempt": "第{count}次重新加载…",
     "filterTitle": "搜索与筛选",
     "itemSize": "显示大小",
+    "themeColor": "主题色",
     "noProgramme": "该频道暂无节目单",
     "exitAppTitle": "退出应用",
     "exitAppMessage": "确定要退出应用吗？",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,7 @@ import 'package:xplayer/providers/mini_player_controller.dart';
 import 'package:xplayer/providers/cast_provider.dart';
 import 'package:xplayer/presentation/widgets/mini_player_overlay.dart';
 import 'package:xplayer/shared/theme/app_theme.dart';
+import 'package:xplayer/shared/theme/theme_settings.dart';
 import 'package:xplayer/services/log_store.dart';
 import 'package:xplayer/utils/player_settings.dart';
 
@@ -60,6 +61,7 @@ void main() {
     loadFavoritesRowSetting(); // 载入「收藏」行显示偏好
     loadMiniPlayerSetting(); // 载入「返回小窗续播」偏好
     loadPipSetting(); // 载入「回桌面画中画」偏好
+    loadThemeColor(); // 载入用户设定的主题强调色
 
     FlutterError.onError = (FlutterErrorDetails details) {
       _winLog('FlutterError: ${details.exceptionAsString()}');
@@ -102,39 +104,44 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     final localeProvider = Provider.of<LocaleProvider>(context);
 
-    return MaterialApp(
-      title: 'XPlayer',
-      debugShowCheckedModeBanner: false,
-      navigatorKey: AppNav.key,
-      localizationsDelegates: const [
-        AppLocalizations.delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-      ],
-      supportedLocales: const [Locale('en'), Locale('zh')],
-      locale: localeProvider.locale,
-      navigatorObservers: [BotToastNavigatorObserver()],
-      builder: (context, child) {
-        // 初始化 BotToast + 注入全局小窗浮层
-        return BotToastInit()(
-          context,
-          Stack(
-            children: [
-              if (child != null) child,
-              const MiniPlayerOverlay(),
-            ],
-          ),
-        );
-      },
-      theme: buildAppTheme(),
-      initialRoute: '/',
-      routes: {
-        '/': (context) => const SplashScreen(),
-        // '/': (context) => const FocusTestPage(),
-        '/playlists': (context) => const PlaylistListScreen(),
-        '/remote': (context) => const RemoteInputScreen(),
-      },
+    // 主色变化时重建 MaterialApp,使 buildAppTheme() 取到新的种子色。
+    // 换色是低频操作,整树重建的代价可接受。
+    return ValueListenableBuilder<Color>(
+      valueListenable: themeColor,
+      builder: (context, _, __) => MaterialApp(
+        title: 'XPlayer',
+        debugShowCheckedModeBanner: false,
+        navigatorKey: AppNav.key,
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: const [Locale('en'), Locale('zh')],
+        locale: localeProvider.locale,
+        navigatorObservers: [BotToastNavigatorObserver()],
+        builder: (context, child) {
+          // 初始化 BotToast + 注入全局小窗浮层
+          return BotToastInit()(
+            context,
+            Stack(
+              children: [
+                if (child != null) child,
+                const MiniPlayerOverlay(),
+              ],
+            ),
+          );
+        },
+        theme: buildAppTheme(),
+        initialRoute: '/',
+        routes: {
+          '/': (context) => const SplashScreen(),
+          // '/': (context) => const FocusTestPage(),
+          '/playlists': (context) => const PlaylistListScreen(),
+          '/remote': (context) => const RemoteInputScreen(),
+        },
+      ),
     );
   }
 }

--- a/lib/presentation/screens/home.dart
+++ b/lib/presentation/screens/home.dart
@@ -39,6 +39,8 @@ import 'package:xplayer/providers/remote_provider.dart';
 import 'package:xplayer/providers/global_provider.dart';
 import 'package:xplayer/providers/mini_player_controller.dart';
 import 'package:xplayer/presentation/screens/player.dart';
+import 'package:xplayer/presentation/widgets/theme_color_dialog.dart';
+import 'package:xplayer/shared/theme/theme_settings.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -571,6 +573,37 @@ class _HomeScreenState extends State<HomeScreen> {
                     Navigator.of(context).pop();
                     _showSizeDialog(context);
                   },
+                ),
+                // 主题强调色:色块 trailing 实时反映当前色
+                ValueListenableBuilder<Color>(
+                  valueListenable: themeColor,
+                  builder: (_, color, __) => XBaseButton(
+                    child: animeContainer(
+                      ListTile(
+                        leading:
+                            const Icon(Icons.palette, color: Colors.white),
+                        title: Text(
+                          localizations.themeColor,
+                          style: const TextStyle(color: Colors.white),
+                        ),
+                        trailing: Container(
+                          width: 24,
+                          height: 24,
+                          decoration: BoxDecoration(
+                            color: color,
+                            shape: BoxShape.circle,
+                          ),
+                        ),
+                      ),
+                    ),
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                      showDialog(
+                        context: context,
+                        builder: (_) => const ThemeColorDialog(),
+                      );
+                    },
+                  ),
                 ),
                 // 首页「最近播放」模块显示开关
                 ValueListenableBuilder<bool>(

--- a/lib/presentation/screens/home.dart
+++ b/lib/presentation/screens/home.dart
@@ -466,188 +466,6 @@ class _HomeScreenState extends State<HomeScreen> {
                   ),
                 ),
                 const Divider(color: Colors.white24, height: 1),
-                _drawerSectionHeader('播放'),
-                // 渲染模式开关:SurfaceView(platformView)/ 纹理。仅非 Android 显示 ——
-                // Android 的清晰度走「播放引擎=原生」(见下),且全局透明下 platformView 会卡;
-                // iOS/macOS(avfoundation 支持 platformView)保留此选项。
-                if (!Platform.isAndroid)
-                  ValueListenableBuilder<bool>(
-                    valueListenable: useSurfaceView,
-                    builder: (_, surface, __) => ListTile(
-                      leading: const Icon(Icons.hd, color: Colors.white),
-                      title: Text(
-                        '${localizations.renderMode}: ${surface ? "SurfaceView" : "Texture"}',
-                        style: const TextStyle(color: Colors.white),
-                      ),
-                      subtitle: Text(
-                        localizations.renderModeHint,
-                        style: const TextStyle(
-                            color: Colors.white54, fontSize: 11),
-                      ),
-                      trailing: Switch(
-                        value: surface,
-                        onChanged: (v) => setUseSurfaceView(v),
-                      ),
-                    ),
-                  ),
-                // 播放引擎开关:原生(SurfaceView,硬件 VPP)/ video_player。仅 Android。
-                if (Platform.isAndroid)
-                  ValueListenableBuilder<bool>(
-                    valueListenable: useNativeEngine,
-                    builder: (_, on, __) => ListTile(
-                      leading: const Icon(Icons.memory, color: Colors.white),
-                      title: Text(
-                        localizations.playerEngine,
-                        style: const TextStyle(color: Colors.white),
-                      ),
-                      subtitle: Text(
-                        on
-                            ? localizations.playerEngineNative
-                            : localizations.playerEngineVideoPlayer,
-                        style: const TextStyle(
-                            color: Colors.white54, fontSize: 11),
-                      ),
-                      trailing: Switch(
-                        value: on,
-                        onChanged: (v) => setUseNativeEngine(v),
-                      ),
-                    ),
-                  ),
-                // 返回首页小窗续播开关(全平台)
-                ValueListenableBuilder<bool>(
-                  valueListenable: miniPlayerOnExit,
-                  builder: (_, on, __) => ListTile(
-                    leading: const Icon(Icons.picture_in_picture_alt,
-                        color: Colors.white),
-                    title: Text(localizations.miniPlayerOnExit,
-                        style: const TextStyle(color: Colors.white)),
-                    subtitle: Text(
-                      localizations.miniPlayerOnExitHint,
-                      style:
-                          const TextStyle(color: Colors.white54, fontSize: 11),
-                    ),
-                    trailing: Switch(
-                      value: on,
-                      onChanged: (v) => setMiniPlayerOnExit(v),
-                    ),
-                  ),
-                ),
-                // 回桌面系统画中画开关(仅 Android 手机/平板;TV 无系统 PiP,隐藏)
-                if (Platform.isAndroid)
-                  Consumer<GlobalProvider>(
-                    builder: (context, g, _) {
-                      if (g.isTV) return const SizedBox.shrink();
-                      return ValueListenableBuilder<bool>(
-                        valueListenable: pipOnLeave,
-                        builder: (_, on, __) => ListTile(
-                          leading: const Icon(Icons.picture_in_picture,
-                              color: Colors.white),
-                          title: Text(localizations.pipOnLeave,
-                              style: const TextStyle(color: Colors.white)),
-                          subtitle: Text(
-                            localizations.pipOnLeaveHint,
-                            style: const TextStyle(
-                                color: Colors.white54, fontSize: 11),
-                          ),
-                          trailing: Switch(
-                            value: on,
-                            onChanged: (v) => setPipOnLeave(v),
-                          ),
-                        ),
-                      );
-                    },
-                  ),
-                _drawerSectionHeader('界面'),
-                XBaseButton(
-                  child: animeContainer(
-                    ListTile(
-                      leading: const Icon(Icons.photo_size_select_large,
-                          color: Colors.white),
-                      title: Text(
-                        localizations.itemSize,
-                        style: const TextStyle(color: Colors.white),
-                      ),
-                    ),
-                  ),
-                  onPressed: () {
-                    Navigator.of(context).pop();
-                    _showSizeDialog(context);
-                  },
-                ),
-                // 主题强调色:色块 trailing 实时反映当前色
-                ValueListenableBuilder<Color>(
-                  valueListenable: themeColor,
-                  builder: (_, color, __) => XBaseButton(
-                    child: animeContainer(
-                      ListTile(
-                        leading:
-                            const Icon(Icons.palette, color: Colors.white),
-                        title: Text(
-                          localizations.themeColor,
-                          style: const TextStyle(color: Colors.white),
-                        ),
-                        trailing: Container(
-                          width: 24,
-                          height: 24,
-                          decoration: BoxDecoration(
-                            color: color,
-                            shape: BoxShape.circle,
-                          ),
-                        ),
-                      ),
-                    ),
-                    onPressed: () {
-                      Navigator.of(context).pop();
-                      showDialog(
-                        context: context,
-                        builder: (_) => const ThemeColorDialog(),
-                      );
-                    },
-                  ),
-                ),
-                // 首页「最近播放」模块显示开关
-                ValueListenableBuilder<bool>(
-                  valueListenable: showRecentModule,
-                  builder: (_, on, __) => ListTile(
-                    leading: const Icon(Icons.history, color: Colors.white),
-                    title: Text(localizations.showRecentOnHome,
-                        style: const TextStyle(color: Colors.white)),
-                    trailing: Switch(
-                      value: on,
-                      onChanged: (v) => setShowRecentModule(v),
-                    ),
-                  ),
-                ),
-                // 首页「收藏」行显示开关
-                ValueListenableBuilder<bool>(
-                  valueListenable: showFavoritesRow,
-                  builder: (_, on, __) => ListTile(
-                    leading: const Icon(Icons.favorite, color: Colors.white),
-                    title: Text(localizations.showFavoritesOnHome,
-                        style: const TextStyle(color: Colors.white)),
-                    trailing: Switch(
-                      value: on,
-                      onChanged: (v) => setShowFavoritesRow(v),
-                    ),
-                  ),
-                ),
-                XBaseButton(
-                  child: animeContainer(
-                    ListTile(
-                      leading: const Icon(Icons.language, color: Colors.white),
-                      title: Text(
-                        localeProvider.locale.languageCode == 'zh'
-                            ? '中文'
-                            : 'English',
-                        style: const TextStyle(color: Colors.white),
-                      ),
-                    ),
-                  ),
-                  onPressed: () {
-                    Navigator.of(context).pop();
-                    _showLanguageSwitcher(context, localeProvider);
-                  },
-                ),
                 _drawerSectionHeader('源与节目单'),
                 Consumer<MediaProvider>(
                   builder: (BuildContext context2, mediaProvider, _) {
@@ -836,6 +654,188 @@ class _HomeScreenState extends State<HomeScreen> {
                       ),
                     ),
                   ),
+                ),
+                _drawerSectionHeader('播放'),
+                // 渲染模式开关:SurfaceView(platformView)/ 纹理。仅非 Android 显示 ——
+                // Android 的清晰度走「播放引擎=原生」(见下),且全局透明下 platformView 会卡;
+                // iOS/macOS(avfoundation 支持 platformView)保留此选项。
+                if (!Platform.isAndroid)
+                  ValueListenableBuilder<bool>(
+                    valueListenable: useSurfaceView,
+                    builder: (_, surface, __) => ListTile(
+                      leading: const Icon(Icons.hd, color: Colors.white),
+                      title: Text(
+                        '${localizations.renderMode}: ${surface ? "SurfaceView" : "Texture"}',
+                        style: const TextStyle(color: Colors.white),
+                      ),
+                      subtitle: Text(
+                        localizations.renderModeHint,
+                        style: const TextStyle(
+                            color: Colors.white54, fontSize: 11),
+                      ),
+                      trailing: Switch(
+                        value: surface,
+                        onChanged: (v) => setUseSurfaceView(v),
+                      ),
+                    ),
+                  ),
+                // 播放引擎开关:原生(SurfaceView,硬件 VPP)/ video_player。仅 Android。
+                if (Platform.isAndroid)
+                  ValueListenableBuilder<bool>(
+                    valueListenable: useNativeEngine,
+                    builder: (_, on, __) => ListTile(
+                      leading: const Icon(Icons.memory, color: Colors.white),
+                      title: Text(
+                        localizations.playerEngine,
+                        style: const TextStyle(color: Colors.white),
+                      ),
+                      subtitle: Text(
+                        on
+                            ? localizations.playerEngineNative
+                            : localizations.playerEngineVideoPlayer,
+                        style: const TextStyle(
+                            color: Colors.white54, fontSize: 11),
+                      ),
+                      trailing: Switch(
+                        value: on,
+                        onChanged: (v) => setUseNativeEngine(v),
+                      ),
+                    ),
+                  ),
+                // 返回首页小窗续播开关(全平台)
+                ValueListenableBuilder<bool>(
+                  valueListenable: miniPlayerOnExit,
+                  builder: (_, on, __) => ListTile(
+                    leading: const Icon(Icons.picture_in_picture_alt,
+                        color: Colors.white),
+                    title: Text(localizations.miniPlayerOnExit,
+                        style: const TextStyle(color: Colors.white)),
+                    subtitle: Text(
+                      localizations.miniPlayerOnExitHint,
+                      style:
+                          const TextStyle(color: Colors.white54, fontSize: 11),
+                    ),
+                    trailing: Switch(
+                      value: on,
+                      onChanged: (v) => setMiniPlayerOnExit(v),
+                    ),
+                  ),
+                ),
+                // 回桌面系统画中画开关(仅 Android 手机/平板;TV 无系统 PiP,隐藏)
+                if (Platform.isAndroid)
+                  Consumer<GlobalProvider>(
+                    builder: (context, g, _) {
+                      if (g.isTV) return const SizedBox.shrink();
+                      return ValueListenableBuilder<bool>(
+                        valueListenable: pipOnLeave,
+                        builder: (_, on, __) => ListTile(
+                          leading: const Icon(Icons.picture_in_picture,
+                              color: Colors.white),
+                          title: Text(localizations.pipOnLeave,
+                              style: const TextStyle(color: Colors.white)),
+                          subtitle: Text(
+                            localizations.pipOnLeaveHint,
+                            style: const TextStyle(
+                                color: Colors.white54, fontSize: 11),
+                          ),
+                          trailing: Switch(
+                            value: on,
+                            onChanged: (v) => setPipOnLeave(v),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                _drawerSectionHeader('界面'),
+                XBaseButton(
+                  child: animeContainer(
+                    ListTile(
+                      leading: const Icon(Icons.photo_size_select_large,
+                          color: Colors.white),
+                      title: Text(
+                        localizations.itemSize,
+                        style: const TextStyle(color: Colors.white),
+                      ),
+                    ),
+                  ),
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    _showSizeDialog(context);
+                  },
+                ),
+                // 主题强调色:色块 trailing 实时反映当前色
+                ValueListenableBuilder<Color>(
+                  valueListenable: themeColor,
+                  builder: (_, color, __) => XBaseButton(
+                    child: animeContainer(
+                      ListTile(
+                        leading:
+                            const Icon(Icons.palette, color: Colors.white),
+                        title: Text(
+                          localizations.themeColor,
+                          style: const TextStyle(color: Colors.white),
+                        ),
+                        trailing: Container(
+                          width: 24,
+                          height: 24,
+                          decoration: BoxDecoration(
+                            color: color,
+                            shape: BoxShape.circle,
+                          ),
+                        ),
+                      ),
+                    ),
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                      showDialog(
+                        context: context,
+                        builder: (_) => const ThemeColorDialog(),
+                      );
+                    },
+                  ),
+                ),
+                // 首页「最近播放」模块显示开关
+                ValueListenableBuilder<bool>(
+                  valueListenable: showRecentModule,
+                  builder: (_, on, __) => ListTile(
+                    leading: const Icon(Icons.history, color: Colors.white),
+                    title: Text(localizations.showRecentOnHome,
+                        style: const TextStyle(color: Colors.white)),
+                    trailing: Switch(
+                      value: on,
+                      onChanged: (v) => setShowRecentModule(v),
+                    ),
+                  ),
+                ),
+                // 首页「收藏」行显示开关
+                ValueListenableBuilder<bool>(
+                  valueListenable: showFavoritesRow,
+                  builder: (_, on, __) => ListTile(
+                    leading: const Icon(Icons.favorite, color: Colors.white),
+                    title: Text(localizations.showFavoritesOnHome,
+                        style: const TextStyle(color: Colors.white)),
+                    trailing: Switch(
+                      value: on,
+                      onChanged: (v) => setShowFavoritesRow(v),
+                    ),
+                  ),
+                ),
+                XBaseButton(
+                  child: animeContainer(
+                    ListTile(
+                      leading: const Icon(Icons.language, color: Colors.white),
+                      title: Text(
+                        localeProvider.locale.languageCode == 'zh'
+                            ? '中文'
+                            : 'English',
+                        style: const TextStyle(color: Colors.white),
+                      ),
+                    ),
+                  ),
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    _showLanguageSwitcher(context, localeProvider);
+                  },
                 ),
                 _drawerSectionHeader('诊断与系统'),
                 XBaseButton(

--- a/lib/presentation/widgets/channel_filter_dialog.dart
+++ b/lib/presentation/widgets/channel_filter_dialog.dart
@@ -3,34 +3,10 @@ import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:xplayer/localization/app_localizations.dart';
 import 'package:xplayer/providers/media_provider.dart';
+import 'package:xplayer/shared/components/x_dialog_shell.dart';
 import 'package:xplayer/shared/components/x_text_button.dart';
 import 'package:xplayer/shared/components/x_icon_button.dart';
 import 'package:xplayer/shared/theme/app_tokens.dart';
-
-/// 三个独立入口共享的弹窗外壳:统一背景/标题/确定按钮。
-class _FilterDialogShell extends StatelessWidget {
-  final String title;
-  final Widget child;
-  const _FilterDialogShell({required this.title, required this.child});
-
-  @override
-  Widget build(BuildContext context) {
-    final l = AppLocalizations.of(context)!;
-    return AlertDialog(
-      backgroundColor: AppTokens.surfacePanel,
-      title:
-          Text(title, style: const TextStyle(color: AppTokens.textPrimary)),
-      content: SizedBox(width: 360, child: child),
-      actions: [
-        XTextButton(
-          text: l.ok,
-          type: XTextButtonType.primary,
-          onPressed: () => Navigator.of(context).pop(),
-        ),
-      ],
-    );
-  }
-}
 
 /// 搜索弹窗(右上角搜索图标打开)。改动即时作用于首页网格。
 class ChannelSearchDialog extends StatefulWidget {
@@ -79,7 +55,7 @@ class _ChannelSearchDialogState extends State<ChannelSearchDialog> {
     final l = AppLocalizations.of(context)!;
     final media = Provider.of<MediaProvider>(context);
 
-    return _FilterDialogShell(
+    return XDialogShell(
       title: l.search,
       child: TextField(
         controller: _controller,
@@ -128,7 +104,7 @@ class ChannelGroupDialog extends StatelessWidget {
     final groups = media.availableGroups;
     final selected = media.selectedGroup;
 
-    return _FilterDialogShell(
+    return XDialogShell(
       title: l.groups,
       child: SingleChildScrollView(
         child: Wrap(
@@ -165,7 +141,7 @@ class ChannelSizeDialog extends StatelessWidget {
     final media = Provider.of<MediaProvider>(context);
     final level = media.gridSizeLevel; // 0 最大 .. 4 最小
 
-    return _FilterDialogShell(
+    return XDialogShell(
       title: l.itemSize,
       child: Row(
         children: [
@@ -200,7 +176,7 @@ class AutoRefreshDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context)!;
-    return _FilterDialogShell(
+    return XDialogShell(
       title: l.autoRefreshOnLaunch,
       child: Consumer<MediaProvider>(
         builder: (context, mp, _) => Column(

--- a/lib/presentation/widgets/theme_color_dialog.dart
+++ b/lib/presentation/widgets/theme_color_dialog.dart
@@ -62,7 +62,7 @@ class _ColorCell extends StatelessWidget {
               : null,
         ),
         child: selected
-            ? const Icon(Icons.check, color: Colors.white, size: 22)
+            ? const Icon(Icons.check, color: AppPalette.onPalette, size: 22)
             : null,
       ),
     );

--- a/lib/presentation/widgets/theme_color_dialog.dart
+++ b/lib/presentation/widgets/theme_color_dialog.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:xplayer/localization/app_localizations.dart';
+import 'package:xplayer/shared/components/x_base_button.dart';
+import 'package:xplayer/shared/components/x_dialog_shell.dart';
+import 'package:xplayer/shared/theme/app_palette.dart';
+import 'package:xplayer/shared/theme/app_tokens.dart';
+import 'package:xplayer/shared/theme/theme_settings.dart';
+
+/// 主题色选择弹窗:4x2 色块网格,选中即时生效。
+/// 用 XBaseButton 承载每个色块,以保证 TV 遥控下有可见焦点框。
+class ThemeColorDialog extends StatelessWidget {
+  const ThemeColorDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context)!;
+    return XDialogShell(
+      title: l.themeColor,
+      child: ValueListenableBuilder<Color>(
+        valueListenable: themeColor,
+        builder: (context, current, __) => GridView.count(
+          crossAxisCount: 4,
+          shrinkWrap: true,
+          mainAxisSpacing: AppDimens.s12,
+          crossAxisSpacing: AppDimens.s12,
+          padding: const EdgeInsets.symmetric(vertical: AppDimens.s8),
+          children: [
+            for (final c in AppPalette.all)
+              _ColorCell(
+                color: c,
+                selected: c.toARGB32() == current.toARGB32(),
+                onTap: () => setThemeColor(c),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ColorCell extends StatelessWidget {
+  final Color color;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _ColorCell({
+    required this.color,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return XBaseButton(
+      onPressed: onTap,
+      child: (focused) => Container(
+        decoration: BoxDecoration(
+          color: color,
+          shape: BoxShape.circle,
+          border: focused
+              ? Border.all(color: AppTokens.textPrimary, width: 3)
+              : null,
+        ),
+        child: selected
+            ? const Icon(Icons.check, color: Colors.white, size: 22)
+            : null,
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/theme_color_dialog.dart
+++ b/lib/presentation/widgets/theme_color_dialog.dart
@@ -53,6 +53,11 @@ class _ColorCell extends StatelessWidget {
   Widget build(BuildContext context) {
     return XBaseButton(
       onPressed: onTap,
+      // TV:打开即把焦点落在当前选中的色块上,与项目其它选择器一致
+      // (player_dialogs / quality_selector / channel_source /
+      //  audio_track_selector / log_center 均为 autofocus: selected)。
+      // 不设的话遥控器用户打开弹窗看不到任何高亮,要多按一次方向键才知道焦点在哪。
+      autofocus: selected,
       child: (focused) => Container(
         decoration: BoxDecoration(
           color: color,

--- a/lib/shared/components/x_dialog_shell.dart
+++ b/lib/shared/components/x_dialog_shell.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:xplayer/localization/app_localizations.dart';
+import 'package:xplayer/shared/components/x_text_button.dart';
+import 'package:xplayer/shared/theme/app_tokens.dart';
+
+/// 各设置类弹窗共享的外壳:统一背景/标题/确定按钮。
+class XDialogShell extends StatelessWidget {
+  final String title;
+  final Widget child;
+  const XDialogShell({super.key, required this.title, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context)!;
+    return AlertDialog(
+      backgroundColor: AppTokens.surfacePanel,
+      title: Text(title, style: const TextStyle(color: AppTokens.textPrimary)),
+      content: SizedBox(width: 360, child: child),
+      actions: [
+        XTextButton(
+          text: l.ok,
+          type: XTextButtonType.primary,
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/shared/theme/app_palette.dart
+++ b/lib/shared/theme/app_palette.dart
@@ -26,6 +26,13 @@ class AppPalette {
   static const Color orange = Color(0xFFFF9800); // 7.38
   static const Color amber = Color(0xFFFFC107); // 9.76
 
+  /// 色块上的前景色(选中对勾)。
+  ///
+  /// 用黑而非白:色板的选色标准要求每个色对深色面板 ≥3:1,这使它们全都是亮色
+  /// (亮度 ≥0.192),而白/黑等对比的临界亮度是 0.179 —— 故黑色标记在 8 色上
+  /// 一律更清晰。实测白色最差仅 1.63(amber),黑色最差 4.84(pink)。
+  static const Color onPalette = Colors.black;
+
   /// 色板顺序。UI 遍历此列表,避免各处重复维护顺序。
   static const List<Color> all = <Color>[
     green,

--- a/lib/shared/theme/app_palette.dart
+++ b/lib/shared/theme/app_palette.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+/// 主题强调色的预设色板。
+///
+/// 选色标准:对 [AppTokens.surfacePanel](#222222,抽屉/弹窗背景,也是主色
+/// 出现最多的场合)的 WCAG 对比度 ≥ 3:1 —— WCAG 2.1 对非文本 UI 组件的
+/// 最低要求。主色驱动 TV 焦点环,对比度不足会让焦点发闷。
+///
+/// 新增颜色必须先过 test/theme/app_palette_test.dart 的对比度断言。
+/// 设计阶段已因此排除紫 #9C27B0(对比度仅 2.52),改用 #BA68C8(4.47)。
+class AppPalette {
+  AppPalette._();
+
+  /// 默认色,即改造前硬编码的品牌色。
+  static const Color green = Color(0xFF00DC82); // 对比度 8.76
+  static const Color blue = Color(0xFF2196F3); // 5.09
+  static const Color cyan = Color(0xFF00BCD4); // 6.93
+  static const Color purple = Color(0xFFBA68C8); // 4.47
+  static const Color pink = Color(0xFFE91E63); // 3.66
+  static const Color red = Color(0xFFF44336); // 4.32
+  static const Color orange = Color(0xFFFF9800); // 7.38
+  static const Color amber = Color(0xFFFFC107); // 9.76
+
+  /// 色板顺序。UI 遍历此列表,避免各处重复维护顺序。
+  static const List<Color> all = <Color>[
+    green,
+    blue,
+    cyan,
+    purple,
+    pink,
+    red,
+    orange,
+    amber,
+  ];
+}

--- a/lib/shared/theme/app_palette.dart
+++ b/lib/shared/theme/app_palette.dart
@@ -1,13 +1,18 @@
 import 'package:flutter/material.dart';
+import 'package:xplayer/shared/theme/app_tokens.dart';
 
 /// 主题强调色的预设色板。
 ///
-/// 选色标准:对 [AppTokens.surfacePanel](#222222,抽屉/弹窗背景,也是主色
+/// 选色标准:对 [AppTokens.surfacePanel] (#222222,抽屉/弹窗背景,也是主色
 /// 出现最多的场合)的 WCAG 对比度 ≥ 3:1 —— WCAG 2.1 对非文本 UI 组件的
 /// 最低要求。主色驱动 TV 焦点环,对比度不足会让焦点发闷。
 ///
-/// 新增颜色必须先过 test/theme/app_palette_test.dart 的对比度断言。
+/// 新增颜色必须:(1) 同时加入下方 [all] 列表,否则 UI 遍历不到;
+/// (2) 先过 test/theme/app_palette_test.dart 的对比度与不透明断言。
 /// 设计阶段已因此排除紫 #9C27B0(对比度仅 2.52),改用 #BA68C8(4.47)。
+///
+/// 注意 `] (` 之间的空格是必需的:去掉就变成 markdown 链接语法,
+/// dartdoc 引用会失效,IDE 悬浮提示里会渲染成一个指向乱码 URL 的链接。
 class AppPalette {
   AppPalette._();
 

--- a/lib/shared/theme/app_tokens.dart
+++ b/lib/shared/theme/app_tokens.dart
@@ -1,17 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:xplayer/shared/theme/theme_settings.dart';
 
 /// XPlayer Design Token 系统（结构参考 BeeCount 的 BeeTokens / BeeDimens）。
 ///
 /// 设计理念：语义化命名统一管理颜色与尺寸，UI 组件应使用 Token 而非散落的字面量。
-/// 现状：单一深色主题（TV / IPTV 场景），**暂未引入暗色模式**，故全部为静态常量，
-/// 无需 context，便于在 CustomPainter、默认参数等无 context 处复用。
+/// 现状：单一深色主题（TV / IPTV 场景），**暂未引入暗色模式**。
+/// 除强调色 [brand] / [focusRing] 外全部为静态常量，无需 context，
+/// 便于在 CustomPainter、默认参数等无 context 处复用。
+/// 强调色由用户设定（见 theme_settings.dart），故为 getter；其余保持 const，
+/// 以免破坏 `const TextStyle(...)` 等现有 const 上下文。
 /// 引入暗色模式时，可改造为 `static Color xxx(BuildContext)` 形式（见 BeeTokens）。
 class AppTokens {
   AppTokens._();
 
   // ========== 品牌色 Brand ==========
-  /// 主色种子（#00dc82）。
-  static const Color brand = Color(0xFF00DC82);
+  /// 主色种子。由用户在「界面 → 主题色」中设定，默认 #00DC82。
+  static Color get brand => themeColor.value;
 
   // ========== 文字 Text ==========
   static const Color textPrimary = Colors.white;
@@ -48,7 +52,7 @@ class AppTokens {
   static const Color fillDefault = Color(0x26FFFFFF);
 
   /// 焦点高亮基色。
-  static const Color focusRing = brand;
+  static Color get focusRing => brand;
 
   // ========== 语义色 Semantic ==========
   static const Color success = Color(0xFF4CAF50);

--- a/lib/shared/theme/theme_settings.dart
+++ b/lib/shared/theme/theme_settings.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:xplayer/shared/theme/app_palette.dart';
+
+/// 主题强调色:驱动焦点高亮、按钮、选中态、进度条、Switch 激活色。
+/// 背景与文字保持深色方案,不受此值影响。
+///
+/// 模式与 lib/utils/player_settings.dart 的各项设置一致:
+/// 全局 ValueNotifier + load/set 函数 + SharedPreferences,存取异常静默吞掉
+/// (设置读写失败不该让 app 挂掉,退回默认值即可)。
+final ValueNotifier<Color> themeColor = ValueNotifier<Color>(AppPalette.green);
+
+const String _kThemeColorKey = 'theme_color';
+
+Future<void> loadThemeColor() async {
+  try {
+    final prefs = await SharedPreferences.getInstance();
+    final v = prefs.getInt(_kThemeColorKey);
+    if (v != null) themeColor.value = Color(v);
+  } catch (_) {}
+}
+
+Future<void> setThemeColor(Color c) async {
+  themeColor.value = c;
+  try {
+    final prefs = await SharedPreferences.getInstance();
+    // Flutter 3.27+ 起 Color.value 已废弃,用 toARGB32()。
+    await prefs.setInt(_kThemeColorKey, c.toARGB32());
+  } catch (_) {}
+}

--- a/test/theme/app_palette_test.dart
+++ b/test/theme/app_palette_test.dart
@@ -1,0 +1,41 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xplayer/shared/theme/app_palette.dart';
+import 'package:xplayer/shared/theme/app_tokens.dart';
+
+/// WCAG 对比度公式:(较亮亮度 + 0.05) / (较暗亮度 + 0.05)
+double _contrast(Color a, Color b) {
+  final la = a.computeLuminance();
+  final lb = b.computeLuminance();
+  return (max(la, lb) + 0.05) / (min(la, lb) + 0.05);
+}
+
+void main() {
+  group('AppPalette', () {
+    test('每个预设色对深色面板的对比度 ≥ 3:1(WCAG 非文本 UI 组件底线)', () {
+      // 主色驱动 TV 焦点环。对比度不足时焦点在深色面板上会发闷,
+      // 用户看不出选中了哪一项 —— 这条断言就是防止色板混进暗色。
+      for (final c in AppPalette.all) {
+        final ratio = _contrast(c, AppTokens.surfacePanel);
+        expect(ratio, greaterThanOrEqualTo(3.0),
+            reason: '$c 对比度仅 ${ratio.toStringAsFixed(2)},'
+                'TV 焦点环会在 #222 面板上发闷');
+      }
+    });
+
+    test('色板无重复色', () {
+      expect(AppPalette.all.toSet().length, AppPalette.all.length);
+    });
+
+    test('默认色仍是原品牌色 #00DC82,老用户升级后观感不变', () {
+      expect(AppPalette.all.first, AppPalette.green);
+      expect(AppPalette.green, const Color(0xFF00DC82));
+    });
+
+    test('色板恰好 8 色(UI 按 4x2 网格布局)', () {
+      expect(AppPalette.all, hasLength(8));
+    });
+  });
+}

--- a/test/theme/app_palette_test.dart
+++ b/test/theme/app_palette_test.dart
@@ -45,5 +45,15 @@ void main() {
         expect(c.a, 1.0, reason: '$c 带 alpha,对比度断言会失真');
       }
     });
+
+    test('选中标记色对每个预设色的对比度 ≥ 3:1(否则看不出选了哪个)', () {
+      // 对勾是选中态的唯一视觉线索。此前用白色时,amber/green/orange/cyan
+      // 四个色上的对比度仅 1.63~2.30,几乎看不出来。
+      for (final c in AppPalette.all) {
+        final ratio = _contrast(AppPalette.onPalette, c);
+        expect(ratio, greaterThanOrEqualTo(3.0),
+            reason: '$c 上的选中对勾对比度仅 ${ratio.toStringAsFixed(2)},看不清');
+      }
+    });
   });
 }

--- a/test/theme/app_palette_test.dart
+++ b/test/theme/app_palette_test.dart
@@ -37,5 +37,13 @@ void main() {
     test('色板恰好 8 色(UI 按 4x2 网格布局)', () {
       expect(AppPalette.all, hasLength(8));
     });
+
+    test('预设色必须全不透明(computeLuminance 无视 alpha,半透明会虚报对比度)', () {
+      // 实测:Color(0x40E91E63) 能以 3.66 通过上面的对比度断言,
+      // 但它叠加到 #222222 上的真实对比度只有 1.24。
+      for (final c in AppPalette.all) {
+        expect(c.a, 1.0, reason: '$c 带 alpha,对比度断言会失真');
+      }
+    });
   });
 }

--- a/test/theme/theme_settings_test.dart
+++ b/test/theme/theme_settings_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:xplayer/shared/theme/app_palette.dart';
+import 'package:xplayer/shared/theme/theme_settings.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    // 每个用例前复位全局 notifier,避免用例间互相污染
+    themeColor.value = AppPalette.green;
+  });
+
+  group('themeColor 持久化', () {
+    test('无存储值时保持默认绿色', () async {
+      SharedPreferences.setMockInitialValues({});
+      await loadThemeColor();
+      expect(themeColor.value, AppPalette.green);
+    });
+
+    test('setThemeColor 立即更新 notifier 并写入存储', () async {
+      SharedPreferences.setMockInitialValues({});
+      await setThemeColor(AppPalette.blue);
+
+      expect(themeColor.value, AppPalette.blue);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getInt('theme_color'), AppPalette.blue.toARGB32());
+    });
+
+    test('load 读回此前存入的颜色', () async {
+      SharedPreferences.setMockInitialValues(
+          {'theme_color': AppPalette.orange.toARGB32()});
+      await loadThemeColor();
+      expect(themeColor.value, AppPalette.orange);
+    });
+
+    test('存储里是任意自定义色值时也能原样读回(为后续取色器留出空间)', () async {
+      const custom = Color(0xFF123456);
+      SharedPreferences.setMockInitialValues({'theme_color': custom.toARGB32()});
+      await loadThemeColor();
+      expect(themeColor.value.toARGB32(), custom.toARGB32());
+    });
+
+    test('notifier 变更会通知监听者', () async {
+      SharedPreferences.setMockInitialValues({});
+      var notified = 0;
+      void listener() => notified++;
+      themeColor.addListener(listener);
+
+      await setThemeColor(AppPalette.red);
+      themeColor.removeListener(listener);
+
+      expect(notified, 1);
+    });
+  });
+}

--- a/test/theme/theme_wiring_test.dart
+++ b/test/theme/theme_wiring_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:xplayer/shared/theme/app_palette.dart';
+import 'package:xplayer/shared/theme/app_theme.dart';
+import 'package:xplayer/shared/theme/app_tokens.dart';
+import 'package:xplayer/shared/theme/theme_settings.dart';
+
+/// 主色接线的端到端验证:themeColor → AppTokens.brand → buildAppTheme() → UI。
+///
+/// 这条链路一旦断掉(例如有人把 MaterialApp 外层的 ValueListenableBuilder 拆了,
+/// 或把 brand 改回 const),换色功能会静默失效 —— 编译照过、测试照绿、
+/// 只有真机上点了色板没反应。故在此锁定。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    themeColor.value = AppPalette.green;
+  });
+
+  test('AppTokens.brand 跟随 themeColor 变化', () {
+    expect(AppTokens.brand, AppPalette.green);
+    themeColor.value = AppPalette.red;
+    expect(AppTokens.brand, AppPalette.red);
+  });
+
+  test('focusRing 始终跟随 brand', () {
+    themeColor.value = AppPalette.amber;
+    expect(AppTokens.focusRing, AppTokens.brand);
+  });
+
+  test('buildAppTheme 的 seed 跟随主色,换色后 colorScheme 不同', () {
+    final green = buildAppTheme().colorScheme.primary;
+    themeColor.value = AppPalette.red;
+    final red = buildAppTheme().colorScheme.primary;
+
+    expect(green, isNot(red),
+        reason: 'buildAppTheme 未跟随主色,seedColor 可能被写死了');
+  });
+
+  testWidgets('换色触发 MaterialApp 重建,Theme.of 取到新主色', (tester) async {
+    // 复刻 main.dart 的接线结构:ValueListenableBuilder 包住 MaterialApp。
+    await tester.pumpWidget(
+      ValueListenableBuilder<Color>(
+        valueListenable: themeColor,
+        builder: (context, _, __) => MaterialApp(
+          theme: buildAppTheme(),
+          home: Builder(
+            builder: (c) => Text(
+              '${Theme.of(c).colorScheme.primary.toARGB32()}',
+              textDirection: TextDirection.ltr,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final before = tester.widget<Text>(find.byType(Text)).data;
+
+    await setThemeColor(AppPalette.red);
+    // 注意必须 pumpAndSettle 而非 pump:MaterialApp 内部用 AnimatedTheme,
+    // 主题切换是带过渡动画的(默认 200ms),单帧 pump 时颜色还在半路。
+    // 这也意味着真机上换色是渐变而非瞬间跳变。
+    await tester.pumpAndSettle();
+
+    final after = tester.widget<Text>(find.byType(Text)).data;
+
+    expect(after, isNot(before),
+        reason: '换色未触发重建 —— MaterialApp 外层的 '
+            'ValueListenableBuilder 可能被拆掉了');
+  });
+}

--- a/test/theme/theme_wiring_test.dart
+++ b/test/theme/theme_wiring_test.dart
@@ -30,6 +30,29 @@ void main() {
     expect(AppTokens.focusRing, AppTokens.brand);
   });
 
+  test('上屏主色是 Material 3 柔化版,并非用户所选的种子色本身', () {
+    // 这条不是及格线,是把一个容易被误解的事实钉住:
+    // ColorScheme.fromSeed 会把任意种子压到 tone-40,饱和度约掉 40%、明度约掉 50%。
+    // 用户选 red(#F44336) 时,Theme.of(context).primaryColor 实际是 #904A42(砖褐)。
+    //
+    // 后果是 app_palette_test.dart 里那条「对 surfacePanel ≥3:1」的护栏,
+    // 管的是种子色 —— 而种子色只在 AppTokens.brand 的直接引用点上屏;
+    // 走 Theme.of(context).primaryColor 的地方(抽屉焦点底色、primary 按钮、
+    // 频道选中态、EPG 高亮、各 Switch)拿到的是柔化版,实测对比度仅 2.46~2.47。
+    //
+    // 不改用种子色作 primary,是因为 x_text_button.dart 的前景色硬编码
+    // Colors.white:primary 一旦变 vivid,amber 上的白字对比度会掉到 1.63,
+    // 按钮文字直接消失。要改需连带引入 onBrand 前景 token(见 PR 的后续项)。
+    for (final c in AppPalette.all) {
+      themeColor.value = c;
+      final onScreen = buildAppTheme().colorScheme.primary;
+
+      expect(onScreen, isNot(c),
+          reason: '$c 竟等于种子色 —— 主题生成方式变了,'
+              '请重新评估 app_palette_test 的护栏是否还测对了对象');
+    }
+  });
+
   test('buildAppTheme 的 seed 跟随主色,换色后 colorScheme 不同', () {
     final green = buildAppTheme().colorScheme.primary;
     themeColor.value = AppPalette.red;


### PR DESCRIPTION
## 改动

**主题色设定** — 8 色预设色板，入口在抽屉「界面 → 主题色」，选中即时生效并持久化。

**抽屉重排** — 「源与节目单」组提到首位（该组 7 项均为高频操作：换播放列表、更新频道/节目单、EPG；而「播放」「界面」是配一次就不再动的设置类）。

## 设计取舍

**只换强调色，不动背景与文字。** 全项目假设深色背景（`textPrimary..textDisabled` 全为白色系、`scrim`/`focusPlayOverlay` 硬编码黑），跟随主色需重算全部对比度，且浅色主色会大面积失效。

**只有 `brand` / `focusRing` 两个 token 变可变**，其余保持 `const`——因为它们被用在 `const TextStyle(...)` 里。前置核查确认 `brand` 全部 8 处引用均不在 const 上下文、`focusRing` 零引用；改造后 `flutter analyze lib/` 逐条比对与 main 基线完全一致，零新增。

**首版只做预设色板。** 自定义取色器 + 亮度校验 + TV 遥控取色交互另开一轮。

## 色板选色标准

对 `AppTokens.surfacePanel`(#222222) 的 WCAG 对比度 ≥ 3:1（WCAG 2.1 对非文本 UI 组件的底线）。设计阶段据此排除了紫 `#9C27B0`（2.52），改用 `#BA68C8`（4.47）。

断言的是对比度而非裸亮度——8 色亮度跨度 0.192~0.594，任何单一亮度阈值都会误杀（卡 0.3 会判掉蓝/紫/红/粉四个，而它们对比度分别是 5.09/4.47/4.32/3.66，全部达标）。

选中对勾用黑色：白/黑等对比的临界亮度是 0.179，而色板 8 色亮度全部 ≥0.192（正因选色标准要求它们对深色面板够亮），故黑色一律更优，最低 4.84（pink）。此前用白色时 amber/green/orange/cyan 四个色上仅 1.63~2.30。

## ⚠️ 已知限制

**1. 用户选的是「种子色」，不是最终显示色**

`ColorScheme.fromSeed` 会把种子压到 Material 3 的 tone-40，饱和度约掉 40%、明度约掉 50%：

| 选择 | 实际上屏 | 对 #222 对比度 |
|---|---|---|
| red `#F44336` | `#904A42` 砖褐 | 4.32 → 2.46 |
| amber `#FFC107` | `#775A0B` 橄榄棕 | 9.76 → 2.46 |
| green `#00DC82` | `#2C6A45` 深墨绿 | 8.76 → 2.47 |

影响范围是走 `Theme.of(context).primaryColor` 的地方（抽屉焦点底色、primary 按钮、频道选中态、EPG 高亮、各 Switch）；走 `AppTokens.brand` 直接引用的 8 处仍是 vivid 种子色。

**pink 与 red 映射后几乎不可区分**（`#8E4957` vs `#904A42`，亮度比 1.004），8 个选项实际约 7 个可辨。

未在本轮改用种子色作 `primary`，是因为 `x_text_button.dart` 的前景色硬编码 `Colors.white`——`primary` 一旦变 vivid，amber 上的白字对比度会掉到 1.63、文字直接消失。要改需连带引入 `onBrand` 前景 token 并在所有「brand 作填充」处配套使用。`theme_wiring_test.dart` 已加断言钉住这个落差，避免绿测试为一个它没验证的性质背书。

**2. 部分次要页面的 `Colors.greenAccent` 不跟随主题色**

`lan_sync_preview_screen.dart:97` 的 `activeColor:` 是真缺口（Switch 激活色本应跟随）；`lan_sync_open_screen.dart:48`、`lan_sync_preview_screen.dart:83`、`log_center_screen.dart:196`、`splash.dart:71` 更像「成功/完成」的语义绿，红色主题下跟着变反而误导。区分需产品判断，故本轮未动。主路径（首页、播放器、抽屉、各设置弹窗）均走 token。

已核实品牌色字面量 `#00DC82` 全项目仅 `app_tokens.dart` 定义处一处，无散落硬编码。

## 验证

- **77 个测试全绿**（main 基线 61 + 新增 16）
- `flutter analyze lib/` = **224 条，与 main 基线逐条一致，零新增、零 error**
- 抽屉重排已证明是纯移动：移动前后文件按行排序后逐行完全一致，总行数不变
- `main.dart` 的 `MaterialApp` 参数一字未改（`git diff -w` 仅 3 处实质改动）
- 色板 8 色对比度经独立 Python 实现验算，与注释数值最大偏差 0.0024
- TV 交互实测：格子 81×81、圆形不变形、方向键遍历路径 `0→1→2→3→(边界不动)→7→6→2` 自然；打开弹窗焦点落在当前选中色块
- 播放中换色不会闪断：`MiniPlayerOverlay` 是 `const` 实例被 `updateChild` 短路、`PlayerScreen` 全文件仅 1 处 `Theme.of` 且在弹窗内、`navigatorKey` 是 GlobalKey 保住路由栈、渲染层 Texture id 稳定

## 后续

1. 自定义取色器 + 亮度校验 + TV 遥控取色交互（本次的对比度断言即是现成护栏）
2. `onBrand` 前景 token，让 `primary` 用回 vivid 种子色（解决上述限制 1）
3. `XDialogShell` 收口：加 `confirmText` / `width` 可选参数，把结构完全相同的 `operation_hint_dialog.dart` 折进来
4. `focusRing` 目前零引用，且「主色驱动 TV 焦点环」这条论证与代码不符（`XBaseButton` 默认焦点态用的是 `focusFillDefault`）——要么删，要么把焦点态真接上去
5. 抽屉 5 个分组标题仍是硬编码中文，英文用户会看到中文分组标题下挂英文条目
6. 上述 `greenAccent` 硬编码的取舍