### PR TITLE
fix(cast): 修复 iOS 投屏搜不到设备(multicast entitlement + SSDP 单播兜底)

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4E7C0A1B2D3F45608A9B0C1D /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		AA870D371C64A28631378918 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		AE1EE532DF2AB231BBFC3AA4 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCE99A82C1B318DC22D4FF57 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
@@ -143,6 +144,7 @@
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
 				97C147021CF9000F007C117D /* Info.plist */,
+				4E7C0A1B2D3F45608A9B0C1D /* Runner.entitlements */,
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
@@ -486,6 +488,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -664,6 +667,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -686,6 +690,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -2,14 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.files.user-selected.read-write</key>
-	<true/>
-	<key>com.apple.security.network.client</key>
-	<true/>
-	<key>com.apple.security.network.server</key>
-	<true/>
 	<key>com.apple.developer.networking.multicast</key>
 	<true/>
 </dict>

--- a/lib/services/cast/dlna_discovery.dart
+++ b/lib/services/cast/dlna_discovery.dart
@@ -5,55 +5,118 @@ import 'package:http/http.dart' as http;
 
 import 'package:xplayer/services/cast/dlna_device.dart';
 import 'package:xplayer/services/cast/dlna_xml.dart';
+import 'package:xplayer/services/log_store.dart';
+
+const _ssdpAddr = '239.255.255.250';
+const _ssdpPort = 1900;
+
+/// 构造 M-SEARCH 报文。
+/// UPnP 1.1:多播请求带 MX,设备在 0~MX 秒内随机回包以防回包风暴;
+/// 单播请求则必须省略 MX,部分渲染器见到 MX 会直接不应答。
+String buildMSearch(String st, {required String host, required bool unicast}) {
+  final b = StringBuffer()
+    ..write('M-SEARCH * HTTP/1.1\r\n')
+    ..write('HOST: $host:$_ssdpPort\r\n')
+    ..write('MAN: "ssdp:discover"\r\n');
+  if (!unicast) b.write('MX: 2\r\n');
+  b.write('ST: $st\r\n\r\n');
+  return b.toString();
+}
+
+/// 由本机 IPv4 推出同 /24 网段内待探测的地址(排除自身、网络号 .0、广播号 .255)。
+/// Dart 的 NetworkInterface 不暴露子网掩码,家用/办公 WiFi 绝大多数是 /24,按此假设;
+/// 猜窄了只是少发现几台设备,不会把探测包发到别人的网段。
+List<String> subnetHostsFor(String ip) {
+  final octets = _octets(ip);
+  if (octets == null) return const [];
+  final prefix = '${octets[0]}.${octets[1]}.${octets[2]}';
+  final self = octets[3];
+  return [
+    for (var i = 1; i <= 254; i++)
+      if (i != self) '$prefix.$i',
+  ];
+}
+
+/// 只在 RFC1918 私有段做逐 IP 探测。对蜂窝/公网地址段扫 254 个端口既发现不了
+/// 客厅电视,又会让 app 的出网流量长得像端口扫描,必须挡住。
+bool isPrivateIPv4(String ip) {
+  final o = _octets(ip);
+  if (o == null) return false;
+  if (o[0] == 10) return true;
+  if (o[0] == 172 && o[1] >= 16 && o[1] <= 31) return true;
+  if (o[0] == 192 && o[1] == 168) return true;
+  return false;
+}
+
+List<int>? _octets(String ip) {
+  final parts = ip.split('.');
+  if (parts.length != 4) return null;
+  final out = <int>[];
+  for (final p in parts) {
+    final v = int.tryParse(p);
+    if (v == null || v < 0 || v > 255) return null;
+    out.add(v);
+  }
+  return out;
+}
 
 /// SSDP 发现局域网内的 DLNA MediaRenderer(自写最小实现,无三方依赖)。
+///
+/// 走两条腿:
+///  - 多播 M-SEARCH:最快,一个包问全网段。但 iOS 14+ 要求
+///    `com.apple.developer.networking.multicast` entitlement(需向 Apple 单独申请),
+///    没有它系统直接拒发 —— 这就是「安卓能搜到设备、iOS 搜不到」的根因。
+///  - 单播 M-SEARCH:逐个 IP 探 1900 端口,不需要任何 multicast 权限,
+///    因此是 iOS 上目前唯一可用的路径;顺带还能捞到被路由器 IGMP snooping
+///    挡掉多播的设备。
 class DlnaDiscovery {
-  static const _ssdpAddr = '239.255.255.250';
-  static const _ssdpPort = 1900;
+  /// 同时问「渲染器设备」和「AVTransport 服务」,兼容只应答其一的渲染器。
+  static const _sts = [
+    'urn:schemas-upnp-org:device:MediaRenderer:1',
+    'urn:schemas-upnp-org:service:AVTransport:1',
+  ];
 
-  String _mSearch(String st) => 'M-SEARCH * HTTP/1.1\r\n'
-      'HOST: $_ssdpAddr:$_ssdpPort\r\n'
-      'MAN: "ssdp:discover"\r\n'
-      'MX: 2\r\n'
-      'ST: $st\r\n\r\n';
+  /// 单播扫描节流:每发这么多个包歇一下。253 个地址 × 2 个 ST ≈ 506 包,
+  /// 按此约 250ms 发完 —— 不至于把自己的发送缓冲冲爆导致丢包。
+  static const _batchSize = 24;
+  static const _batchGap = Duration(milliseconds: 12);
 
-  /// 搜索 [timeout] 时长,返回去重后的设备列表。
+  /// 搜索 [timeout] 时长(含发包耗时),返回去重后的设备列表。
   Future<List<DlnaDevice>> search(
       {Duration timeout = const Duration(seconds: 4)}) async {
-    RawDatagramSocket? socket;
+    final deadline = DateTime.now().add(timeout);
     final seenLocations = <String>{};
     final pending = <Future<DlnaDevice?>>[];
-    try {
-      socket = await RawDatagramSocket.bind(InternetAddress.anyIPv4, 0);
-      socket.multicastHops = 4;
 
+    final socket = await _bind();
+    if (socket == null) return const [];
+
+    try {
       socket.listen((event) {
         if (event != RawSocketEvent.read) return;
-        final dg = socket!.receive();
+        final dg = socket.receive();
         if (dg == null) return;
-        final resp = String.fromCharCodes(dg.data);
-        final loc = parseSsdpLocation(resp);
+        final loc = parseSsdpLocation(String.fromCharCodes(dg.data));
         if (loc == null || !seenLocations.add(loc)) return;
         pending.add(_resolve(loc));
       });
 
-      final target = InternetAddress(_ssdpAddr);
-      // 同时搜 MediaRenderer 设备与 AVTransport 服务,兼容只回其一的渲染器;发两轮防丢包。
-      for (final st in const [
-        'urn:schemas-upnp-org:device:MediaRenderer:1',
-        'urn:schemas-upnp-org:service:AVTransport:1',
-      ]) {
-        final pkt = _mSearch(st).codeUnits;
-        socket.send(pkt, target, _ssdpPort);
-        await Future<void>.delayed(const Duration(milliseconds: 150));
-        socket.send(pkt, target, _ssdpPort);
+      // 两条腿分开 try:多播被系统拒绝时,单播扫描必须照常进行。
+      final multicastOk = await _sendMulticast(socket);
+      final unicastSent = await _sendUnicastSweep(socket);
+      if (!multicastOk) {
+        LogStore.instance.w('cast',
+            'SSDP 多播不可用(iOS 需 multicast entitlement),本轮仅靠单播扫描');
+      }
+      if (!multicastOk && unicastSent == 0) {
+        LogStore.instance
+            .e('cast', '多播与单播都没发出去,无法发现设备:检查本地网络权限与 WiFi 连接');
       }
 
-      await Future<void>.delayed(timeout);
-    } catch (_) {
-      // 多播失败(权限/网络)→ 返回已收集到的
+      final rest = deadline.difference(DateTime.now());
+      if (rest > Duration.zero) await Future<void>.delayed(rest);
     } finally {
-      socket?.close();
+      socket.close();
     }
 
     final resolved = await Future.wait(pending);
@@ -61,16 +124,100 @@ class DlnaDiscovery {
     for (final d in resolved) {
       if (d != null) byUdn[d.udn] = d;
     }
+    LogStore.instance.i('cast',
+        '发现结束:收到 ${seenLocations.length} 个 SSDP 应答,解析出 ${byUdn.length} 台可投设备');
     return byUdn.values.toList();
+  }
+
+  Future<RawDatagramSocket?> _bind() async {
+    try {
+      return await RawDatagramSocket.bind(InternetAddress.anyIPv4, 0);
+    } catch (e) {
+      LogStore.instance.e('cast', 'SSDP socket 绑定失败,无法发现设备:$e');
+      return null;
+    }
+  }
+
+  /// 发多播 M-SEARCH。返回是否至少发出去一个包。
+  Future<bool> _sendMulticast(RawDatagramSocket socket) async {
+    var anySent = false;
+    try {
+      socket.multicastHops = 4;
+      final target = InternetAddress(_ssdpAddr);
+      for (final st in _sts) {
+        final pkt = buildMSearch(st, host: _ssdpAddr, unicast: false).codeUnits;
+        // 发两轮防丢包(UDP 无重传)。
+        for (var i = 0; i < 2; i++) {
+          if (socket.send(pkt, target, _ssdpPort) > 0) anySent = true;
+          await Future<void>.delayed(const Duration(milliseconds: 150));
+        }
+      }
+    } catch (e) {
+      // iOS 无 multicast entitlement 时这里是 SocketException(errno 65)。
+      LogStore.instance.w('cast', '多播 M-SEARCH 被拒:$e');
+      return false;
+    }
+    return anySent;
+  }
+
+  /// 对本机所在私有 /24 网段逐个 IP 发单播 M-SEARCH。返回实际发出的包数。
+  Future<int> _sendUnicastSweep(RawDatagramSocket socket) async {
+    final targets = await _scanTargets();
+    if (targets.isEmpty) {
+      LogStore.instance.w('cast', '未找到可扫描的私有网段(没连 WiFi?),跳过单播发现');
+      return 0;
+    }
+
+    var sent = 0;
+    var inBatch = 0;
+    for (final ip in targets) {
+      final addr = InternetAddress(ip);
+      for (final st in _sts) {
+        try {
+          final pkt = buildMSearch(st, host: ip, unicast: true).codeUnits;
+          if (socket.send(pkt, addr, _ssdpPort) > 0) sent++;
+        } catch (_) {
+          // 个别地址不可达(ENETUNREACH)属正常,不影响整轮扫描。
+        }
+      }
+      if (++inBatch >= _batchSize) {
+        inBatch = 0;
+        await Future<void>.delayed(_batchGap);
+      }
+    }
+    LogStore.instance
+        .d('cast', '单播扫描:${targets.length} 个地址,发出 $sent 个探测包');
+    return sent;
+  }
+
+  /// 本机所有私有网段 /24 内的待探测地址(多网卡合并去重)。
+  Future<List<String>> _scanTargets() async {
+    final List<NetworkInterface> ifaces;
+    try {
+      ifaces = await NetworkInterface.list(
+          includeLoopback: false, type: InternetAddressType.IPv4);
+    } catch (e) {
+      LogStore.instance.w('cast', '枚举网卡失败:$e');
+      return const [];
+    }
+
+    final out = <String>{};
+    for (final iface in ifaces) {
+      for (final addr in iface.addresses) {
+        if (!isPrivateIPv4(addr.address)) continue;
+        LogStore.instance
+            .d('cast', '扫描网段 ${addr.address}/24 (${iface.name})');
+        out.addAll(subnetHostsFor(addr.address));
+      }
+    }
+    return out.toList();
   }
 
   /// 拉取设备描述文档并解析为 DlnaDevice;失败/非 AVTransport 设备返回 null。
   Future<DlnaDevice?> _resolve(String location) async {
     try {
       final uri = Uri.parse(location);
-      final res = await http
-          .get(uri)
-          .timeout(const Duration(seconds: 3));
+      final res = await http.get(uri).timeout(const Duration(seconds: 3));
       if (res.statusCode != 200) return null;
       final desc = parseDeviceDescription(res.body, uri);
       if (desc == null) return null;
@@ -80,7 +227,8 @@ class DlnaDiscovery {
         location: uri,
         controlUrl: desc.controlUrl,
       );
-    } catch (_) {
+    } catch (e) {
+      LogStore.instance.d('cast', '设备描述拉取失败 $location:$e');
       return null;
     }
   }

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -12,5 +12,7 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.developer.networking.multicast</key>
+	<true/>
 </dict>
 </plist>

--- a/test/cast/ssdp_scan_test.dart
+++ b/test/cast/ssdp_scan_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xplayer/services/cast/dlna_discovery.dart';
+
+void main() {
+  group('buildMSearch', () {
+    test('多播报文:HOST 指向 SSDP 组播地址,带 MX 让设备错开回包', () {
+      final msg =
+          buildMSearch('urn:schemas-upnp-org:device:MediaRenderer:1',
+              host: '239.255.255.250', unicast: false);
+
+      expect(msg, startsWith('M-SEARCH * HTTP/1.1\r\n'));
+      expect(msg, contains('HOST: 239.255.255.250:1900\r\n'));
+      expect(msg, contains('MAN: "ssdp:discover"\r\n'));
+      expect(msg, contains('MX: 2\r\n'));
+      expect(msg, contains('ST: urn:schemas-upnp-org:device:MediaRenderer:1\r\n'));
+      expect(msg, endsWith('\r\n\r\n'));
+    });
+
+    test('单播报文:HOST 指向目标设备,且不含 MX(UPnP 1.1 要求单播省略)', () {
+      final msg = buildMSearch('urn:schemas-upnp-org:service:AVTransport:1',
+          host: '192.168.1.23', unicast: true);
+
+      expect(msg, contains('HOST: 192.168.1.23:1900\r\n'));
+      expect(msg, isNot(contains('MX:')));
+      expect(msg, contains('ST: urn:schemas-upnp-org:service:AVTransport:1\r\n'));
+      expect(msg, endsWith('\r\n\r\n'));
+    });
+  });
+
+  group('subnetHostsFor', () {
+    test('推出同 /24 网段全部主机,排除自身/网络号/广播号', () {
+      final hosts = subnetHostsFor('192.168.1.100');
+
+      expect(hosts, hasLength(253)); // 1..254 去掉自身
+      expect(hosts, contains('192.168.1.1'));
+      expect(hosts, contains('192.168.1.254'));
+      expect(hosts, isNot(contains('192.168.1.100'))); // 自身
+      expect(hosts, isNot(contains('192.168.1.0'))); // 网络号
+      expect(hosts, isNot(contains('192.168.1.255'))); // 广播号
+    });
+
+    test('自身是 .1 时仍扫满其余 253 个', () {
+      final hosts = subnetHostsFor('10.0.0.1');
+
+      expect(hosts, hasLength(253));
+      expect(hosts, isNot(contains('10.0.0.1')));
+      expect(hosts.first, '10.0.0.2');
+    });
+
+    test('非法输入返回空,不产生扫描流量', () {
+      expect(subnetHostsFor('192.168.1'), isEmpty);
+      expect(subnetHostsFor(''), isEmpty);
+      expect(subnetHostsFor('fe80::1'), isEmpty);
+      expect(subnetHostsFor('192.168.1.abc'), isEmpty);
+    });
+  });
+
+  group('isPrivateIPv4', () {
+    test('三段私有地址段都认', () {
+      expect(isPrivateIPv4('192.168.1.5'), isTrue);
+      expect(isPrivateIPv4('10.1.2.3'), isTrue);
+      expect(isPrivateIPv4('172.16.0.1'), isTrue);
+      expect(isPrivateIPv4('172.31.255.254'), isTrue);
+    });
+
+    test('公网与 172.32+ 不认,避免把扫描打到蜂窝/公网', () {
+      expect(isPrivateIPv4('8.8.8.8'), isFalse);
+      expect(isPrivateIPv4('172.32.0.1'), isFalse);
+      expect(isPrivateIPv4('172.15.0.1'), isFalse);
+      expect(isPrivateIPv4('100.64.0.1'), isFalse); // 运营商级 NAT
+    });
+
+    test('link-local 不扫(169.254 上没有 DLNA 渲染器)', () {
+      expect(isPrivateIPv4('169.254.1.1'), isFalse);
+    });
+
+    test('非法输入不认', () {
+      expect(isPrivateIPv4('192.168.1'), isFalse);
+      expect(isPrivateIPv4(''), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## 问题

iOS 上投屏搜不到设备,安卓正常。

根因是 iOS 14+ 对多播的限制:发多播 M-SEARCH 需要
`com.apple.developer.networking.multicast` entitlement(需向 Apple 单独申请),
没有它系统直接拒发 —— 而原实现把这个失败 `catch (_) {}` 吞掉了,所以表现成
「搜索正常结束、就是一台设备都没有」,完全无从排查。

## 改动

**1. 多播权限(entitlement)—— 这才是真正的修复**

Apple 已批准该权限。

- 新增 `ios/Runner/Runner.entitlements`,接到 Debug/Release/Profile 三套配置
- macOS 两个 entitlements 补 multicast 键
- macOS `Release.entitlements` 另补 `network.server`:沙盒下 SSDP 要 bind UDP
  socket 收应答。此前只有 `DebugProfile` 带它(Flutter 模板默认,给 Dart VM
  用的),Release build 少了它连发现都做不了。投屏没有平台门控,macOS 上按钮
  照样出现,所以这是真实缺口。

**2. 错误不再静默 —— 分支里的主要收益**

多播被拒、socket 绑定失败、网卡枚举失败、设备描述拉取失败,现在都写进 LogStore,
诊断中心可见。两条腿分开 try,多播失败不影响后续流程。

正是原来那个 `catch (_) {}` 让这个 bug 一开始完全无法排查——失败和「网里真没设备」
表现得一模一样。

**3. SSDP 单播兜底 —— 实测对主流老电视无效,聊胜于无**

逐个 IP 探同 /24 网段的 1900 端口,不需要多播权限。

⚠️ **真机取证结论**:测试用的两台设备(LG SmartShare、Cling/2.0)SERVER 标头
都是 `UPnP/1.0`,而单播 M-SEARCH 是 UPnP 1.1 才引入的可选特性。同一网络下
多播能发现 2 台,单播 506 个包发出、**0 个响应**。

所以它只对 UPnP 1.1 设备有用,不能当作多播的等价替代。保留它的理由是成本低
(~250ms 发完)且能捞到被路由器 IGMP snooping 挡掉的设备,但别指望它兜底。
安全边界:只扫 RFC1918 私有段(公网/蜂窝直接跳过,否则出网流量长得像端口扫描),
单播报文按 UPnP 1.1 省略 MX,分批节流避免冲爆发送缓冲。

## 验证

- 86 个测试全过(新增 9 条 SSDP 报文构造/网段推导/私有段判定测试)
- `flutter analyze lib/services/cast/ test/cast/` 零问题
- 本地 iOS 设备构建通过,`codesign -d --entitlements` 确认
  `com.apple.developer.networking.multicast` 已签入 `Runner.app`

## ⚠️ 合并后发版前必做

CI 走**手动签名**,描述文件存在 secret 里,不会自动更新。需要用重新生成的描述
文件更新这两个 secret,否则打 tag 会在 `xcodebuild archive` 直接失败:

- `APPLE_PROVISIONING_PROFILE`(iOS)
- `MACOS_PROVISIONING_PROFILE`(macOS)
